### PR TITLE
WIP: Benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vs/
+.vscode/
 bin/
 obj/
 .nupkgs/
+BenchmarkDotNet.Artifacts/
 *.diagsession

--- a/Pipelines.Sockets.Unofficial.sln
+++ b/Pipelines.Sockets.Unofficial.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pipelines.Sockets.Unofficia
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicRunner", "tests\BasicRunner\BasicRunner.csproj", "{09B5FEBD-2B46-4294-9545-C2058E44A813}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "tests\Benchmarks\Benchmarks.csproj", "{E2F83D6A-00C6-4085-8BA5-A3EF9FBD61B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,10 @@ Global
 		{09B5FEBD-2B46-4294-9545-C2058E44A813}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09B5FEBD-2B46-4294-9545-C2058E44A813}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09B5FEBD-2B46-4294-9545-C2058E44A813}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2F83D6A-00C6-4085-8BA5-A3EF9FBD61B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2F83D6A-00C6-4085-8BA5-A3EF9FBD61B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2F83D6A-00C6-4085-8BA5-A3EF9FBD61B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2F83D6A-00C6-4085-8BA5-A3EF9FBD61B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/Benchmarks/App.config
+++ b/tests/Benchmarks/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/Benchmarks/BasicTests.cs
+++ b/tests/Benchmarks/BasicTests.cs
@@ -1,0 +1,29 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pipelines.Sockets.Unofficial.Tests;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Benchmarks
+{
+    [KeepBenchmarkFiles]
+    [Config(typeof(Config))]
+    public class BasicTests
+    {
+        public static PingPongTests PPTests { get; } = new PingPongTests(TextWriter.Null);
+
+        [Benchmark(Baseline = true, Description = "Socket=>Pipelines=>PingPong")]
+        public Task BasicPipelines() => PPTests.Basic_Pipelines_PingPong();
+
+        [Benchmark(Description = "Socket=>NetworkStream=>PingPong")]
+        public Task BasicNetworkStream() => PPTests.Basic_NetworkStream_PingPong();
+
+        [Benchmark(Description = "Socket=>Pipelines=>TRW=>PingPong")]
+        public Task BasicPipelinesText() => PPTests.Basic_Pipelines_Text_PingPong();
+
+        [Benchmark(Description = "Socket=>NetworkStream=>TRW=>PingPong")]
+        public Task BasicNetworkStreamText() => PPTests.Basic_NetworkStream_Text_PingPong();
+
+        [Benchmark(Description = "Socket=>NetworkStream=>Pipelines=>PingPong")]
+        public Task BasicNetworkStreamPipelines() => PPTests.Basic_NetworkStream_Pipelines_PingPong();
+    }
+}

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <!--<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Pipelines.Sockets.Unofficial\Pipelines.Sockets.Unofficial.csproj" />
+    <ProjectReference Include="..\Pipelines.Sockets.Unofficial.Tests\Pipelines.Sockets.Unofficial.Tests.csproj" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\somesite.pfx" Link="somesite.pfx" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="somesite.cert" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -1,0 +1,30 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using System.Reflection;
+
+namespace Benchmarks
+{
+    public static class Program
+    {
+        public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
+    }
+
+    internal class Config : ManualConfig
+    {
+        public Config()
+        {
+            Job Get(Job j) => j.With(RunStrategy.Monitoring)
+                               .WithLaunchCount(1)
+                               .WithWarmupCount(1)
+                               .WithTargetCount(5)
+                               .WithInvocationCount(5);
+
+            Add(new MemoryDiagnoser());
+            Add(Get(Job.Clr));
+            Add(Get(Job.Core));
+        }
+    }
+}

--- a/tests/Benchmarks/TLSTests.cs
+++ b/tests/Benchmarks/TLSTests.cs
@@ -1,0 +1,22 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pipelines.Sockets.Unofficial.Tests;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Benchmarks
+{
+    [Config(typeof(Config))]
+    public class TLSTests
+    {
+        public static PingPongTests PPTests { get; } = new PingPongTests(TextWriter.Null);
+
+        [Benchmark(Description = "Socket=>Pipelines=>Inverter=>SslStream=>Inverter=>PingPong")]
+        public Task BasicPipelines() => PPTests.ServerClientDoubleInverted_SslStream_PingPong();
+
+        [Benchmark(Description = "Socket=>NetworkStream=>SslStream=>PingPong")]
+        public Task BasicNetworkStream() => PPTests.ServerClient_SslStream_PingPong();
+
+        [Benchmark(Description = "Socket=>NetworkStream=>SslStream=>Inverter=>PingPong")]
+        public Task BasicPipelinesText() => PPTests.ServerClient_SslStream_Inverter_PingPong();
+    }
+}


### PR DESCRIPTION
This *should* setup a benchmark repo to compare the various scenarios in the quick test app as well as include allocations for each so we can tune there. However, there's a problem with our favorite friend binding redirects. If you run the tests here via:
```
dotnet run -p .\tests\Benchmarks\ -c Release -f netcoreapp2.1 Basic
```
You'll see the problem on the very first test (ignore the warning about XML comments, they are irrelevant to this):
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.IO.FileLoadException: Could not load file or assembly 'System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
   at System.Buffers.ArrayMemoryPool`1.ArrayMemoryPoolBuffer..ctor(Int32 size)
   at System.Buffers.ArrayMemoryPool`1.Rent(Int32 minimumBufferSize)
```

#### Solutions! Just kidding, I have none.

I have tried:
```
<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
```
With and without `app.config` in place. Without our current `app.config`, the `System.Buffers` 4.0.2 => 4.0.3 redirect is not created. With the `app.config` in place, it's added. Note that BenchmarkDotNet creates it's own project and compile for every run. To that end, I have added `[KeepBenchmarkFiles]` on `BasicTests` so these are left around to investigate. It *appears* correct, the redirect is there. But, it still errors in the same way.

I have tried just removing `app.config`.
I have tried referencing `System.Buffers` 4.5.0 directly. That's the 4.0.3 DLL, 4.4.0 is 4.0.2, which is what `System.IO.Pipelines` references...the source of our conflict.
I have tried crying, but that didn't seem to help either.

Posting this up as a public PR in case anyone wants to lose some hair with me. Who knows, maybe it's a bug in BenchmarkDotNet.

Note: this runs CLR jobs first to demonstrate the binding failure on `System.Buffers` ASAP.