### PR TITLE
update BDN to 0.11.4 which ignores assembly binding redirect issues

### DIFF
--- a/tests/Benchmark/ArenaBenchmarks.cs
+++ b/tests/Benchmark/ArenaBenchmarks.cs
@@ -7,7 +7,6 @@ using System.Linq;
 
 namespace Benchmark
 {
-    [MemoryDiagnoser, CoreJob, ClrJob]
     public class ArenaBenchmarks
     {
         private readonly int[][] _sizes;

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0-pre-05" />
     <ProjectReference Include="..\..\src\Pipelines.Sockets.Unofficial\Pipelines.Sockets.Unofficial.csproj" />
   </ItemGroup>


### PR DESCRIPTION
@mgravell I was able to repro your issue, the fix is to update to BDN 0.11.4 which ignores assembly binding redirects issues if it's able to find missing `.dll`

```log
// BeforeAnythingElse
// Wrong assembly binding redirects for System.Runtime.CompilerServices.Unsafe, loading it from disk anyway.

// Benchmark Process Environment Information:
```

To run against multiple runtimes:

```cmd
dotnet run -c Release -f net472 --filter *ArenaBenchmarks* --runtimes net472 netcoreapp2.0 netcoreapp2.1
```
To enable memory diagnoser:

```cmd
--memory 
```

or just

```cmd
-m
```
