### PR TITLE
Optimizations around MutexSlim

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/Threading/MutexSlim.AsyncDirectPendingLockSlab.cs
+++ b/src/Pipelines.Sockets.Unofficial/Threading/MutexSlim.AsyncDirectPendingLockSlab.cs
@@ -43,18 +43,7 @@ namespace Pipelines.Sockets.Unofficial.Threading
             }
 
             ValueTaskSourceStatus IValueTaskSource<LockToken>.GetStatus(short token)
-            {
-                ref State item = ref _items[token];
-                switch (LockState.GetState(Volatile.Read(ref item.Token)))
-                {
-                    case LockState.Canceled:
-                        return ValueTaskSourceStatus.Canceled;
-                    case LockState.Pending:
-                        return ValueTaskSourceStatus.Pending;
-                    default: // LockState.Success, LockState.Timeout (we only have 4 bits for status)
-                        return ValueTaskSourceStatus.Succeeded;
-                }
-            }
+                => LockState.GetStatus(ref _items[token].Token);
 
             void IValueTaskSource<LockToken>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
             {

--- a/src/Pipelines.Sockets.Unofficial/Threading/MutexSlim.LockState.cs
+++ b/src/Pipelines.Sockets.Unofficial/Threading/MutexSlim.LockState.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks.Sources;
 
 namespace Pipelines.Sockets.Unofficial.Threading
 {
@@ -31,6 +32,20 @@ namespace Pipelines.Sockets.Unofficial.Threading
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static int GetState(int token) => token & 3;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ValueTaskSourceStatus GetStatus(ref int token)
+            {
+                switch (LockState.GetState(Volatile.Read(ref token)))
+                {
+                    case LockState.Canceled:
+                        return ValueTaskSourceStatus.Canceled;
+                    case LockState.Pending:
+                        return ValueTaskSourceStatus.Pending;
+                    default: // LockState.Success, LockState.Timeout (we only have 4 bits for status)
+                        return ValueTaskSourceStatus.Succeeded;
+                }
+            }
 
             // "completed", in Task/ValueTask terms, includes cancelation - only omits pending
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Pipelines.Sockets.Unofficial/Threading/MutexSlim.cs
+++ b/src/Pipelines.Sockets.Unofficial/Threading/MutexSlim.cs
@@ -1,7 +1,6 @@
 ﻿using Pipelines.Sockets.Unofficial.Internal;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;

--- a/tests/Benchmark/ArenaBenchmarks.cs
+++ b/tests/Benchmark/ArenaBenchmarks.cs
@@ -10,7 +10,7 @@ namespace Benchmark
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
-    public class ArenaBenchmarks
+    public class ArenaBenchmarks : BenchmarkBase
     {
         private readonly int[][] _sizes;
         private readonly int _maxCount;

--- a/tests/Benchmark/ArenaBenchmarks.cs
+++ b/tests/Benchmark/ArenaBenchmarks.cs
@@ -493,7 +493,7 @@ namespace Benchmark
 
         [BenchmarkCategory("allocate")]
         [Benchmark(Description = "OwnedArena<int>.Allocate (no sharing)")]
-        public void Alloc_Arena_Owned_NoSharingg()
+        public void Alloc_Arena_Owned_NoSharing()
         {
             var owned = _multiArenaNoSharing.GetArena<int>();
             for (int i = 0; i < _sizes.Length; i++)

--- a/tests/Benchmark/LockBenchmarks.cs
+++ b/tests/Benchmark/LockBenchmarks.cs
@@ -1,7 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
-using Pipelines.Sockets.Unofficial;
 using Pipelines.Sockets.Unofficial.Threading;
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,7 +10,7 @@ namespace Benchmark
     public class LockBenchmarks : BenchmarkBase
     {
         const int TIMEOUTMS = 2000;
-        private readonly MutexSlim _mutexSlim = new MutexSlim(TIMEOUTMS, DedicatedThreadPoolPipeScheduler.Default);
+        private readonly MutexSlim _mutexSlim = new MutexSlim(TIMEOUTMS);
         private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 #if !NO_NITO
         private readonly Nito.AsyncEx.AsyncSemaphore _asyncSemaphore = new Nito.AsyncEx.AsyncSemaphore(1);

--- a/tests/Benchmark/Program.cs
+++ b/tests/Benchmark/Program.cs
@@ -1,10 +1,17 @@
 ﻿using BenchmarkDotNet.Running;
+using System;
 
 namespace Benchmark
 {
     internal static class Program
     {
         private static void Main(string[] args)
-            => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        {
+            if (args == null || args.Length == 0)
+            {   // if no args, we're probably using Ctrl+F5 in the IDE; enlargen thyself!
+                try { Console.WindowWidth = Console.LargestWindowWidth - 20; } catch { }
+            }
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
     }
 }

--- a/tests/Benchmark/Utils.cs
+++ b/tests/Benchmark/Utils.cs
@@ -6,13 +6,13 @@ namespace Benchmark
     {
         public static int AssertIs(this int actual, int expected)
         {
-            if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
+            // if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
             return actual;
         }
 
         public static long AssertIs(this long actual, long expected)
         {
-            if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
+            // if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
             return actual;
         }
     }

--- a/tests/Benchmark/Utils.cs
+++ b/tests/Benchmark/Utils.cs
@@ -2,6 +2,10 @@
 
 namespace Benchmark
 {
+    public abstract class BenchmarkBase
+    {
+        public Action<string> Log;
+    }
     internal static class Utils
     {
         public static int AssertIs(this int actual, int expected)

--- a/tests/Benchmark/Utils.cs
+++ b/tests/Benchmark/Utils.cs
@@ -6,13 +6,13 @@ namespace Benchmark
     {
         public static int AssertIs(this int actual, int expected)
         {
-            // if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
+            if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
             return actual;
         }
 
         public static long AssertIs(this long actual, long expected)
         {
-            // if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
+            if (actual != expected) throw new InvalidOperationException($"expected {expected} but was {actual}");
             return actual;
         }
     }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace Pipelines.Sockets.Unofficial.Tests
 {
     public abstract class BenchmarkTests<T> : IDisposable
-        where T : class, new()
+        where T : BenchmarkBase, new()
     {
         private T _instance = new T();
         private readonly int _defaultTimes;
@@ -18,6 +18,7 @@ namespace Pipelines.Sockets.Unofficial.Tests
         public BenchmarkTests(ITestOutputHelper output, int? defaultTimes = null)
         {
             Output = output;
+            _instance.Log += s => Output.WriteLine(s);
             _defaultTimes = defaultTimes ?? 1;
         }
 

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -1,6 +1,7 @@
 ﻿using Benchmark;
 using BenchmarkDotNet.Attributes;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -8,74 +9,125 @@ using Xunit.Abstractions;
 
 namespace Pipelines.Sockets.Unofficial.Tests
 {
-    public class BenchmarkTests
+    public abstract class BenchmarkTests<T> : IDisposable
+        where T : class, new()
     {
+        private T _instance = new T();
+        private readonly int _defaultTimes;
         public ITestOutputHelper Output { get; }
-
-        public BenchmarkTests(ITestOutputHelper output) => Output = output;
-
-        [Fact]
-        public Task RunArenaBenchmarksAsTests() => Run<ArenaBenchmarks>();
-
-        [Fact]
-        public Task RunLockBenchmarksAsTests() => Run<LockBenchmarks>();
-
-        private async Task Run<T>() where T : class, new()
+        public BenchmarkTests(ITestOutputHelper output, int? defaultTimes = null)
         {
-            var obj = new T();
-            int failures = 0, total = 0;
-            using (obj as IDisposable)
-            {
-                foreach (var method in typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance))
-                {
-                    if (Attribute.IsDefined(method, typeof(BenchmarkAttribute)))
-                    {
-                        var args = method.GetParameters();
-                        if (args != null && args.Length != 0)
-                        {
-                            Output.WriteLine($"skipping {method.Name} - unclear parameters");
-                        }
-
-                        Output.WriteLine($"running {method.Name}...");
-                        try
-                        {
-                            var result = method.Invoke(obj, null);
-                            if (result == null) { }
-                            else if (result is Task t) await t;
-                            else if (result is ValueTask vt)
-                            {
-                                await vt;
-                            }
-                            else
-                            {
-                                Type type = result.GetType();
-                                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
-                                {
-                                    await (Task)s_await.MakeGenericMethod(type.GetGenericArguments()).Invoke(null, new object[] { result });
-                                }
-                            }
-                            Output.WriteLine($"completed {method.Name}: {result}");
-                        }
-                        catch (Exception ex)
-                        {
-                            if (ex is TargetInvocationException tie && tie.InnerException != null)
-                            {
-                                ex = ex.InnerException;
-                            }
-                            Output.WriteLine($"faulted {method.Name}: {ex.GetType().Name} '{ex.Message}'");
-                            failures++;
-                        }
-                        total++;
-                    }
-                }
-            }
-            Output.WriteLine($"total failures: {failures} of {total}");
-            Assert.Equal(0, failures);
+            Output = output;
+            _defaultTimes = defaultTimes ?? 1;
         }
 
-        static readonly MethodInfo s_await = typeof(BenchmarkTests).GetMethod(nameof(AwaitTypedValueTask));
-#pragma warning disable xUnit1013 // Public method should be marked as test
-        public static async Task AwaitTypedValueTask<T>(ValueTask<T> vt) => await vt;
-#pragma warning restore xUnit1013 // Public method should be marked as test
+        public void Dispose()
+        {
+            using (_instance as IDisposable) { }
+            _instance = null;
+        }
+
+        private void Write<TResult>(TResult value) => Output?.WriteLine(value?.ToString() ?? "(null)");
+
+        public async Task Run<TResult>(Func<T, TResult> action, int? times = null)
+        {
+            int runs = times ?? _defaultTimes;
+            for (int i = 0; i < runs; i++)
+                Write(action(_instance));
+            await Task.CompletedTask; // to get same exception/etc handling as the others
+        }
+        public async Task Run(Action<T> action, int? times = null)
+        {
+            int runs = times ?? _defaultTimes;
+            for (int i = 0; i < runs; i++)
+                action(_instance);
+            await Task.CompletedTask; // to get same exception/etc handling as the others
+        }
+        public async Task Run(Func<T, Task> action, int? times = null)
+        {
+            int runs = times ?? _defaultTimes;
+            for (int i = 0; i < runs; i++)
+                await action(_instance);
+        }
+        public async Task Run(Func<T, ValueTask> action, int? times = null)
+        {
+            int runs = times ?? _defaultTimes;
+            for (int i = 0; i < runs; i++)
+                await action(_instance);
+        }
+        public async Task Run<TResult>(Func<T, Task<TResult>> action, int? times = null)
+        {
+            int runs = times ?? _defaultTimes;
+            for (int i = 0; i < runs; i++)
+                Write(await action(_instance));
+        }
+        public async Task Run<TResult>(Func<T, ValueTask<TResult>> action, int? times = null)
+        {
+            int runs = times ?? _defaultTimes;
+            for (int i = 0; i < runs; i++)
+                Write(await action(_instance));
+        }
+
+        [MemberData(nameof(GetMethods))]
+        [Theory]
+        public void HasTestMethods(string methodName)
+        {
+            var found = GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(found);
+            Assert.Equal(typeof(Task), found.ReturnType);
+        }
+        public static IEnumerable<object[]> GetMethods()
+        {
+            foreach(var method in typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (Attribute.IsDefined(method, typeof(BenchmarkAttribute)))
+                    yield return new object[] { method.Name };
+            }
+        }
+
+        
+
+    }
+    public class ArenaBenchmarkTests : BenchmarkTests<ArenaBenchmarks>
+    {
+        public ArenaBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
+
+        [Fact] public Task Alloc_ArenaT() => Run(_ => _.Alloc_ArenaT());
+        [Fact] public Task Alloc_Arena_Default() => Run(_ => _.Alloc_Arena_Default());
+        [Fact] public Task Alloc_Arena_NoPadding() => Run(_ => _.Alloc_Arena_NoPadding());
+        [Fact] public Task Alloc_Arena_NoSharing() => Run(_ => _.Alloc_Arena_NoSharing());
+        [Fact] public Task Alloc_Arena_Owned_Default() => Run(_ => _.Alloc_Arena_Owned_Default());
+        [Fact] public Task Alloc_Arena_Owned_NoPadding() => Run(_ => _.Alloc_Arena_Owned_NoPadding());
+        [Fact] public Task Alloc_Arena_Owned_NoSharing() => Run(_ => _.Alloc_Arena_Owned_NoSharing());
+        [Fact] public Task Alloc_ArrayPool() => Run(_ => _.Alloc_ArrayPool());
+        [Fact] public Task Alloc_NewArray() => Run(_ => _.Alloc_NewArray());
+        [Fact] public Task ReadArenaForeachRefAdd() => Run(_ => _.ReadArenaForeachRefAdd());
+        [Fact] public Task ReadArenaSegmentsFor() => Run(_ => _.ReadArenaSegmentsFor());
+        [Fact] public Task ReadArenaSpansFor() => Run(_ => _.ReadArenaSpansFor());
+        [Fact] public Task ReadArrayFor() => Run(_ => _.ReadArrayFor());
+        [Fact] public Task ReadArrayForeach() => Run(_ => _.ReadArrayForeach());
+        [Fact] public Task ReadArrayPoolFor() => Run(_ => _.ReadArrayPoolFor());
+        [Fact] public Task ReadArrayPoolForeach() => Run(_ => _.ReadArrayPoolForeach());
+        [Fact] public Task WriteArenaSegmentsFor() => Run(_ => _.WriteArenaSegmentsFor());
+        [Fact] public Task WriteArenaSpansFor() => Run(_ => _.WriteArenaSpansFor());
+        [Fact] public Task WriteArrayFor() => Run(_ => _.WriteArrayFor());
+        [Fact] public Task WriteArrayPoolFor() => Run(_ => _.WriteArrayPoolFor());
+    }
+    public class LockBenchmarkTests : BenchmarkTests<LockBenchmarks>
+    {
+        public LockBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
+
+        [Fact] public Task Monitor_Sync() => Run(_ => _.Monitor_Sync());
+        [Fact] public Task MutexSlim_Async() => Run(_ => _.MutexSlim_Async());
+        [Fact] public Task MutexSlim_Async_HotPath() => Run(_ => _.MutexSlim_Async_HotPath());
+        [Fact(Skip = "sync-over-async")] public Task MutexSlim_ConcurrentLoad() => Run(_ => _.MutexSlim_ConcurrentLoad());
+        [Fact] public Task MutexSlim_ConcurrentLoadAsync() => Run(_ => _.MutexSlim_ConcurrentLoadAsync());
+        [Fact] public Task MutexSlim_ConcurrentLoadAsync_DisableContext() => Run(_ => _.MutexSlim_ConcurrentLoadAsync_DisableContext());
+        [Fact] public Task MutexSlim_Sync() => Run(_ => _.MutexSlim_Sync());
+        [Fact] public Task SemaphoreSlim_Async() => Run(_ => _.SemaphoreSlim_Async());
+        [Fact] public Task SemaphoreSlim_Async_HotPath() => Run(_ => _.SemaphoreSlim_Async_HotPath());
+        [Fact(Skip = "sync-over-async")] public Task SemaphoreSlim_ConcurrentLoad() => Run(_ => _.SemaphoreSlim_ConcurrentLoad());
+        [Fact] public Task SemaphoreSlim_ConcurrentLoadAsync() => Run(_ => _.SemaphoreSlim_ConcurrentLoadAsync());
+        [Fact] public Task SemaphoreSlim_Sync() => Run(_ => _.SemaphoreSlim_Sync());
     }
 }


### PR DESCRIPTION
- simplifies the way state is held for the no-context case, allowing us to use fewer arrays
- removes a spin-wait in the async path that can cause thread-pool exhaustion
- improves tests