### PR TITLE
Streams

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
@@ -65,8 +65,5 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             _offset += items;
             return true;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void Invalidate() => _count = 0;
     }
 }

--- a/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Pipelines.Sockets.Unofficial.Arenas
+{
+    internal struct FastState<T> // not actually a buffer as such - just prevents
+    {                                   // us constantly having to slice etc
+        public void Init(in SequencePosition position, long remaining)
+        {
+            if (position.GetObject() is ReadOnlySequenceSegment<T> segment
+                && MemoryMarshal.TryGetArray(segment.Memory, out var array))
+            {
+                int offset = position.GetInteger();
+                _array = array.Array;
+                _offset = offset; // the net offset into the array
+                _count = (int)Math.Min( // the smaller of (noting it will always be an int)
+                        array.Count - offset, // the amount left in this buffer
+                        remaining); // the logical amount left in the stream
+            }
+            else
+            {
+                this = default;
+            }
+        }
+
+        public override string ToString() => $"{_count} remaining";
+
+        T[] _array;
+        int _count, _offset;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryAdd(in T item)
+        {
+            if (_count != 0)
+            {
+                _array[_offset++] = item;
+                _count--;
+                return true;
+            }
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int TryRead(Span<T> span)
+        {
+            var items = Math.Min(span.Length, _count);
+            if (items != 0)
+            {
+                new Span<T>(_array, _offset, items).CopyTo(span);
+                _count -= items;
+                _offset += items;
+            }
+            return items;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryWrite(ReadOnlySpan<T> span)
+        {
+            int items = span.Length;
+            if (_count < items) return false;
+            span.CopyTo(new Span<T>(_array, _offset, items));
+            _count -= items;
+            _offset += items;
+            return true;
+        }
+    }
+}

--- a/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -29,6 +30,12 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
         T[] _array;
         int _count, _offset;
+
+        public bool IsEmpty
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _count == 0;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryAdd(in T item)
@@ -64,6 +71,20 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             _count -= items;
             _offset += items;
             return true;
+        }
+
+        internal int AddRange(IEnumerator<T> iter)
+        {
+            // to get here, we are expecting at least one element in iter
+            int added = 0;
+            do
+            {
+                if (_count == 0) return ~added;
+                _array[_offset++] = iter.Current;
+                _count--;
+                added++;
+            } while (iter.MoveNext());
+            return added;
         }
     }
 }

--- a/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/FastStateT.cs
@@ -14,7 +14,7 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             {
                 int offset = position.GetInteger();
                 _array = array.Array;
-                _offset = offset; // the net offset into the array
+                _offset = offset + array.Offset; // the net offset into the array
                 _count = (int)Math.Min( // the smaller of (noting it will always be an int)
                         array.Count - offset, // the amount left in this buffer
                         remaining); // the logical amount left in the stream
@@ -65,5 +65,8 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             _offset += items;
             return true;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Invalidate() => _count = 0;
     }
 }

--- a/src/Pipelines.Sockets.Unofficial/Arenas/LeasedSegmentT.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/LeasedSegmentT.cs
@@ -1,0 +1,78 @@
+﻿using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Pipelines.Sockets.Unofficial.Arenas
+{
+    internal sealed class LeasedSegment<T> : SequenceSegment<T>
+    {
+#if DEBUG
+        internal static long s_leaseCount;
+#endif
+        internal static LeasedSegment<T> Create(int minimumSize, LeasedSegment<T> previous)
+        {
+            var array = ArrayPool<T>.Shared.Rent(minimumSize);
+#if DEBUG
+            Interlocked.Increment(ref s_leaseCount);
+#endif
+
+            // try and get from the pool, noting that we might be squabbling
+            for (int i = 0; i < 5; i++)
+            {
+                LeasedSegment<T> oldHead;
+                if (Volatile.Read(ref s_poolSize) == 0
+                    || (oldHead = Volatile.Read(ref s_poolHead)) == null) break;
+                var newHead = (LeasedSegment<T>)oldHead.Next;
+
+                if (Interlocked.CompareExchange(ref s_poolHead, newHead, oldHead) == oldHead)
+                {
+                    Interlocked.Decrement(ref s_poolSize); // doesn't need to be hard in lock-step with the actual length
+                    oldHead.Init(array, previous);
+                    return oldHead;
+                }
+            }
+            return new LeasedSegment<T>(array, previous);
+        }
+
+        static void PushToPool(LeasedSegment<T> segment)
+        {
+            if (segment == null) return;
+            for (int i = 0; i < 5; i++)
+            {
+                if (Volatile.Read(ref s_poolSize) >= MAX_RECYCLED) return;
+
+                var oldHead = Volatile.Read(ref s_poolHead);
+                segment.SetNext(oldHead);
+                if (Interlocked.CompareExchange(ref s_poolHead, segment, oldHead) == oldHead)
+                {
+                    Interlocked.Increment(ref s_poolSize); // doesn't need to be hard in lock-step with the actual length
+                    return;
+                }
+            }
+        }
+
+        const int MAX_RECYCLED = 50; // hold a small number of LeasedSegment tokens for re-use
+        static LeasedSegment<T> s_poolHead;
+        static int s_poolSize;
+
+        private LeasedSegment(T[] array, LeasedSegment<T> previous) : base(array, previous) { }
+
+        internal void CascadeRelease(bool inclusive)
+        {
+            var segment = inclusive ? this : (LeasedSegment<T>)ResetNext();
+            while (segment != null)
+            {
+                if (MemoryMarshal.TryGetArray<T>(segment.ResetMemory(), out var array))
+                {
+                    ArrayPool<T>.Shared.Return(array.Array);
+#if DEBUG
+                    Interlocked.Decrement(ref s_leaseCount);
+#endif
+                }
+                var next = (LeasedSegment<T>)segment.ResetNext();
+                PushToPool(segment);
+                segment = next;
+            }
+        }
+    }
+}

--- a/src/Pipelines.Sockets.Unofficial/Arenas/Sequence.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/Sequence.cs
@@ -734,6 +734,24 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         }
 
         /// <summary>
+        /// Clear (set to zero) this sequence
+        /// </summary>
+        public void Clear()
+        {
+            if(IsSingleSegment)
+            {
+                FirstSpan.Clear();
+            }
+            else
+            {
+                foreach(var span in Spans)
+                {
+                    span.Clear();
+                }
+            }
+        }
+
+        /// <summary>
         /// Create a new single-segment sequence from a memory
         /// </summary>
 #pragma warning disable RCS1231

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceExtensions.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceExtensions.cs
@@ -355,9 +355,17 @@ namespace Pipelines.Sockets.Unofficial.Arenas
                 var iter = destination.Spans.GetEnumerator();
                 while(!source.IsEmpty)
                 {
-                    var span = iter.GetNext();
-                    source.Slice(0, span.Length).CopyTo(span);
-                    source = source.Slice(span.Length);
+                    var dest = iter.GetNext();
+                    if (dest.Length >= source.Length)
+                    {
+                        source.CopyTo(dest);
+                        break;
+                    }
+                    else
+                    {
+                        source.Slice(0, dest.Length).CopyTo(dest);
+                        source = source.Slice(dest.Length);
+                    }
                 }
             }
             return true;

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.Immutable.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.Immutable.cs
@@ -1,0 +1,35 @@
+﻿using Pipelines.Sockets.Unofficial.Internal;
+
+namespace Pipelines.Sockets.Unofficial.Arenas
+{
+    public abstract partial class SequenceList<T>
+    {
+        /// <summary>
+        /// Provides an empty immutable list
+        /// </summary>
+        public static SequenceList<T> Empty { get; } = new ImmutableSequenceList<T>(default);
+
+        /// <summary>
+        /// Create a new non-appendable list based on a pre-existing sequences
+        /// </summary>
+        /// <param name="sequence"></param>
+        public static SequenceList<T> Create(in Sequence<T> sequence)
+            => sequence.IsEmpty ? Empty : new ImmutableSequenceList<T>(in sequence);
+    }
+
+    internal sealed class ImmutableSequenceList<T> : SequenceList<T>
+    {
+        private readonly Sequence<T> _sequence;
+
+        internal ImmutableSequenceList(in Sequence<T> sequence) => _sequence = sequence;
+
+        private protected override ref T GetByIndex(int index) => ref _sequence[index];
+
+        private protected override int CapacityImpl() => checked((int)_sequence.Length);
+        private protected override int CountImpl() => checked((int)_sequence.Length);
+        private protected override Sequence<T> GetSequence() => _sequence;
+        private protected override bool IsReadOnly => true;
+        private protected override void ClearImpl() => Throw.NotSupported();
+        private protected override void AddImpl(in T value) => Throw.NotSupported();
+    }
+}

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.Mutable.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.Mutable.cs
@@ -1,0 +1,101 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Pipelines.Sockets.Unofficial.Arenas
+{
+
+    public partial class SequenceList<T>
+    {
+        private protected SequenceList() { }
+
+        /// <summary>
+        /// Create a new mutable list based on a sequence
+        /// </summary>
+        public static SequenceList<T> Create(int capacity = 0)
+            => new MutableSequenceList<T>(capacity);
+    }
+
+    internal sealed class MutableSequenceList<T> : SequenceList<T>
+    {
+        Sequence<T> _sequence;
+        int _count, _capacity;
+        FastState<T> _appendState;
+
+        internal MutableSequenceList(int capacity)
+        {
+            // _sequence is default, but that is fine
+            if (capacity != 0)
+            {
+                _sequence = _sequence.ExpandCapacity(length: capacity, maxCapacity: capacity);
+                _capacity = capacity;
+                Debug.Assert(capacity == checked((int)_sequence.Length), "expected capacity parity");
+                InitAppendState();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void InitAppendState() => _appendState.Init(_sequence.GetPosition(_count), _capacity - _count);
+
+        private protected override int CapacityImpl() => _capacity;
+        private protected override int CountImpl() => _count;
+        private protected override bool IsReadOnly => false;
+        private protected override Sequence<T> GetSequence() => _sequence.Slice(0, _count);
+        private protected override void ClearImpl()
+        {
+            if (!PerTypeHelpers<T>.IsBlittable & _count != 0)
+            {   // wipe the ortion that we've used
+                GetSequence().Clear();
+            }
+            _count = 0;
+            InitAppendState();
+        }
+
+        private protected override ref T GetByIndex(int index) => ref _sequence[index];
+
+        private protected override void AddImpl(in T value)
+        {
+            if (_appendState.TryAdd(in value))
+            {
+                _count++;
+            }
+            else
+            {
+                SlowAdd(in value);
+            }
+        }
+        private void SlowAdd(in T value)
+        {
+            if (_count == _sequence.Length) Expand();
+            Debug.Assert(_count < Capacity);
+            _sequence[_count++] = value;
+        }
+
+        private void Expand()
+        {
+            _sequence = _sequence.ExpandCapacity(
+                length: _capacity + 20,
+                maxCapacity: int.MaxValue);
+            _capacity = checked((int)_sequence.Length);
+            InitAppendState();
+        }
+
+        private protected override void TrimImpl()
+        {
+            if (_count == _capacity | _capacity == 0) return; // nothing to do
+
+            if (_count == 0)
+            {
+                var node = (LeasedSegment<T>)_sequence.Start.GetObject();
+                _sequence = default;
+                node?.CascadeRelease(inclusive: true);
+                _capacity = 0;
+            }
+            else
+            {
+                var retain = (LeasedSegment<T>)_sequence.GetPosition(_count).GetObject();
+                retain.CascadeRelease(inclusive: false);
+                _capacity = checked((int)_sequence.Length);
+            }
+        }
+    }
+}

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.Mutable.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.Mutable.cs
@@ -14,52 +14,6 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         /// </summary>
         public static SequenceList<T> Create(int capacity = 0)
             => new MutableSequenceList<T>(capacity);
-
-        ///// <summary>
-        ///// Allows optimized append to a sequence-based list
-        ///// </summary>
-        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //public virtual Appender GetAppender() => GetAppenderImpl();
-
-        //private protected virtual Appender GetAppenderImpl()
-        //{
-        //    Throw.NotSupported();
-        //    return default;
-        //}
-
-        ///// <summary>
-        ///// Allows optimized append to a sequence-based list
-        ///// </summary>
-        //public ref struct Appender
-        //{
-        //    private readonly MutableSequenceList<T> _parent;
-        //    private Span<T> _span;
-        //    int _offset, _count;
-        //    internal Appender(MutableSequenceList<T> parent)
-        //    {
-        //        _parent = parent;
-        //        _span = parent.GetAppendState(out _offset, out _count);
-        //    }
-
-        //    /// <summary>
-        //    /// Add a value to the list
-        //    /// </summary>
-        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //    public void Add(in T value)
-        //    {
-        //        if (_count == 0) Expand();
-        //        _span[_offset++] = value;
-        //        _count--;
-        //        _parent.OnAdded();
-        //    }
-
-        //    [MethodImpl(MethodImplOptions.NoInlining)]
-        //    private void Expand()
-        //    {
-        //        if (_parent.Count == _parent.Capacity) _parent.Expand();
-        //        _span = _parent.GetAppendState(out _offset, out _count);
-        //    }
-        //}
     }
 
     internal sealed class MutableSequenceList<T> : SequenceList<T>
@@ -67,8 +21,6 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         Sequence<T> _sequence;
         int _count, _capacity;
         FastState<T> _appendState;
-
-        // private protected override Appender GetAppenderImpl() => new Appender(this);
 
         internal MutableSequenceList(int capacity)
         {
@@ -84,20 +36,6 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void InitAppendState() => _appendState.Init(_sequence.GetPosition(_count), _capacity - _count);
-
-        //internal Span<T> GetAppendState(out int offset, out int count)
-        //{
-        //    var position = _sequence.GetPosition(_count);
-        //    if (position.GetObject() is SequenceSegment<T> segment)
-        //    {
-        //        var span = segment.Memory.Span;
-        //        offset = position.GetInteger(); // the net offset into the array
-        //        count = span.Length - offset;
-        //        return span;
-        //    }
-        //    offset = count = 0;
-        //    return default;
-        //}
 
         private protected override int CapacityImpl() => _capacity;
         private protected override int CountImpl() => _count;
@@ -160,12 +98,5 @@ namespace Pipelines.Sockets.Unofficial.Arenas
                 _capacity = checked((int)_sequence.Length);
             }
         }
-
-        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //internal void OnAdded()
-        //{
-        //    _count++;
-        //    _appendState.Invalidate();
-        //}
     }
 }

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceList.cs
@@ -11,14 +11,22 @@ namespace Pipelines.Sockets.Unofficial.Arenas
     /// <summary>
     /// A list-like reference type that can be used in most APIs that expect a list object
     /// </summary>
-    public class SequenceList<T> : IList<T>, IReadOnlyList<T>, IList
+    public abstract partial class SequenceList<T> : IList<T>, IReadOnlyList<T>, IList
     {
-        private static readonly SequenceList<T> s_empty = new SequenceList<T>(default);
+        private protected abstract bool IsReadOnly { get; }
+        private protected abstract int CountImpl();
+        private protected abstract int CapacityImpl();
+        private protected abstract Sequence<T> GetSequence();
 
-        internal static SequenceList<T> Create(in Sequence<T> sequence)
-            => sequence.IsEmpty ? s_empty: new SequenceList<T>(sequence);
+        private protected abstract void AddImpl(in T element);
+        private protected abstract void ClearImpl();
 
-        private readonly Sequence<T> _sequence;
+        /// <summary>
+        /// Release any unused segments used by this list
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Trim() => TrimImpl();
+        private protected virtual void TrimImpl() { }
 
         /// <summary>
         /// Returns the size of the list
@@ -26,14 +34,23 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         public int Count
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => checked((int)_sequence.Length);
+            get => CountImpl();
+        }
+
+        /// <summary>
+        /// Returns the capacity of the underlying sequence
+        /// </summary>
+        public int Capacity
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => CapacityImpl();
         }
 
         /// <summary>
         /// Allows a sequence to be enumerated as values
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Sequence<T>.Enumerator GetEnumerator() => _sequence.GetEnumerator();
+        public Sequence<T>.Enumerator GetEnumerator() => GetSequence().GetEnumerator();
 
         /// <summary>
         /// Provide a reference to an element by index
@@ -41,25 +58,23 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref _sequence[index];
+            get => ref GetByIndex(index);
         }
 
-        internal SequenceList(in Sequence<T> sequence) => _sequence = sequence;
+        private protected abstract ref T GetByIndex(int index);
 
         /// <summary>
         /// Get the sequence represented by this list
         /// </summary>
-        public Sequence<T> ToSequence() => _sequence;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Sequence<T> ToSequence() => GetSequence();
 
-        // everything from here is to make the interfaces happy
 
-        bool ICollection<T>.IsReadOnly => true; // means add/remove
+        bool ICollection<T>.IsReadOnly => IsReadOnly; // means add/remove
 
         bool IList.IsReadOnly => false; // ambiguous - means add/remove/modify; we allow modify, so...
 
-        bool IList.IsFixedSize => true; // means add/remove
-
-        int ICollection.Count => Count;
+        bool IList.IsFixedSize => IsReadOnly; // means add/remove
 
         object ICollection.SyncRoot => this;
 
@@ -83,12 +98,13 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
         private int IndexOf(T item)
         {
-            if (!_sequence.IsEmpty)
+            var sequence = GetSequence();
+            if (!sequence.IsEmpty)
             {
                 var comparer = EqualityComparer<T>.Default;
-                if (_sequence.IsSingleSegment)
+                if (sequence.IsSingleSegment)
                 {
-                    var span = _sequence.FirstSpan;
+                    var span = sequence.FirstSpan;
                     for (int i = 0; i < span.Length; i++)
                     {
                         if (comparer.Equals(item, span[i])) return i;
@@ -97,7 +113,7 @@ namespace Pipelines.Sockets.Unofficial.Arenas
                 else
                 {
                     int offset = 0;
-                    foreach (var span in _sequence.Spans)
+                    foreach (var span in sequence.Spans)
                     {
                         for (int i = 0; i < span.Length; i++)
                         {
@@ -112,38 +128,60 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
         int IList<T>.IndexOf(T item) => IndexOf(item);
 
-        void IList<T>.Insert(int index, T item) => Throw.NotSupported();
+        void IList<T>.Insert(int index, T item) {
+            if (index == CountImpl()) AddImpl(item);
+            else Throw.NotSupported();
+        }
 
         void IList<T>.RemoveAt(int index) => Throw.NotSupported();
 
-        void ICollection<T>.Add(T item) => Throw.NotSupported();
+        /// <summary>
+        /// An a new element to the list
+        /// </summary>
+        [CLSCompliant(false)]
+        public void Add(in T value) => AddImpl(in value);
 
-        void ICollection<T>.Clear() => Throw.NotSupported();
+        void ICollection<T>.Add(T value) => AddImpl(in value);
+
+        void ICollection<T>.Clear() => ClearImpl();
+        void IList.Clear() => ClearImpl();
+
+        /// <summary>
+        /// Remove all elements from the list, optionally releasing all segments
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear(bool trim = false)
+        {
+            ClearImpl();
+            if (trim) TrimImpl();
+        }
 
         bool ICollection<T>.Contains(T item) => IndexOf(item) >= 0;
 
         private void CopyTo(T[] array, int arrayIndex)
-            => _sequence.CopyTo(new Span<T>(array, arrayIndex, array.Length - arrayIndex));
+            => GetSequence().CopyTo(new Span<T>(array, arrayIndex, array.Length - arrayIndex));
 
         void ICollection<T>.CopyTo(T[] array, int arrayIndex) => CopyTo(array, arrayIndex);
 
         bool ICollection<T>.Remove(T item) { Throw.NotSupported(); return default; }
 
-        private unsafe IEnumerator<T> GetObjectEnumerator() => _sequence.GetObjectEnumerator();
+        private unsafe IEnumerator<T> GetObjectEnumerator() => GetSequence().GetObjectEnumerator();
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => _sequence.GetObjectEnumerator();
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetSequence().GetObjectEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetObjectEnumerator();
 
-        int IList.Add(object value) { Throw.NotSupported(); return default; }
+        int IList.Add(object value) { Add((T)value); return CountImpl() - 1; }
 
         bool IList.Contains(object value) => IndexOf((T)value) >= 0;
 
-        void IList.Clear() => Throw.NotSupported();
-
         int IList.IndexOf(object value) => IndexOf((T)value);
 
-        void IList.Insert(int index, object value) => Throw.NotSupported();
+        void IList.Insert(int index, object value)
+        {
+            if (index == CountImpl()) AddImpl((T)value);
+            else Throw.NotSupported();
+        }
 
         void IList.Remove(object value) => Throw.NotSupported();
 

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceSegment.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceSegment.cs
@@ -64,8 +64,20 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         /// Creates a new SequenceSegment, optionally attaching the segment to an existing chain
         /// </summary>
         protected SequenceSegment(Memory<T> memory, SequenceSegment<T> previous = null)
+            => Init(memory, previous);
+
+        /// <summary>
+        /// Reconfigure an existing SequenceSegment; this may result in undefined behaviour in existing chains,
+        /// and should only be used if you control the lifetime of the sequences using this segment
+        /// </summary>
+        protected void Init(Memory<T> memory, SequenceSegment<T> previous = null)
         {
-            if (previous != null)
+            Next = null;
+            if (previous == null)
+            {
+                RunningIndex = 0;
+            }
+            else
             {
                 var oldNext = previous.Next;
                 if (oldNext != null) Throw.InvalidOperation("The previous segment already has an onwards chain");
@@ -74,6 +86,12 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             }
             Memory = memory; // also sets Length
         }
+
+        /// <summary>
+        /// Reconfigure an existing SequenceSegment; this may result in undefined behaviour in existing chains,
+        /// and should only be used if you control the lifetime of the sequences using this segment
+        /// </summary>
+        protected void SetNext(SequenceSegment<T> next) => Next = next;
 
         int ISegment.ElementSize => Unsafe.SizeOf<T>();
         void IDisposable.Dispose() { } // just to satisfy IMemoryOwner<T>

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceSegment.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceSegment.cs
@@ -136,6 +136,17 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private set => base.Next = value;
         }
+        
+        /// <summary>
+        /// Resets the Memory associated with this sequence; this may result in undefined behaviour in existing chains,
+        /// and should only be used if you control the lifetime of the sequences using this segment
+        /// </summary>
+        protected Memory<T> ResetMemory()
+        {
+            var old = Memory;
+            Memory = default;
+            return old;
+        }
 
         /// <summary>
         /// The memory represented by this segment

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceSegment.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceSegment.cs
@@ -149,6 +149,17 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         }
 
         /// <summary>
+        /// Resets the next segment associated with this sequence; this may result in undefined behaviour in existing chains,
+        /// and should only be used if you control the lifetime of the sequences using this segment
+        /// </summary>
+        protected SequenceSegment<T> ResetNext()
+        {
+            var old = Next;
+            Next = default;
+            return old;
+        }
+
+        /// <summary>
         /// The memory represented by this segment
         /// </summary>
         public new Memory<T> Memory

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceStream.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceStream.cs
@@ -1,0 +1,381 @@
+﻿using Pipelines.Sockets.Unofficial.Internal;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pipelines.Sockets.Unofficial.Arenas
+{
+    public sealed class SequenceStream : Stream
+    {
+        private readonly Sequence<byte> _sequence;
+        private long _length, _capacity, _position;
+
+        public SequenceStream()
+        {
+            _sequence = default; // sequence;
+        }
+
+        public Sequence<byte> GetBuffer() => _sequence.Slice(0, _length); // don't over-report, since we don't have to
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => true;
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override void Flush() { }
+        public override bool CanTimeout => false;
+        public override void Write(byte[] buffer, int offset, int count) => Throw.NotSupported();
+        public override long Position
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _position;
+            set
+            {
+                if (_position < 0 | _position > _length) Throw.ArgumentOutOfRange(nameof(Position));
+                _position = value;
+            }
+        }
+
+        public override long Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _length;
+        }
+
+        public override void SetLength(long value)
+        {
+            if(value == _length)
+            {
+                // nothing to do
+            }
+            else if (value < _length)
+            {
+                // getting smaller; simple
+                _position = Math.Min(_position, value);
+                _length = value;
+            }
+            else
+            {
+                // getting bigger
+                var oldLen = _length;
+                Expand(value);
+                _sequence.Slice(oldLen, value - oldLen).Clear(); // wipe
+            }
+        }
+
+        private void Expand(long length)
+        {
+            if (length < _length)
+            {
+                if (_capacity < length)
+                {
+                    throw new NotImplementedException();
+                }
+                _length = length;
+            }
+        }
+
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Current:
+                    Position += offset;
+                    break;
+                case SeekOrigin.Begin:
+                    Position = offset;
+                    break;
+                case SeekOrigin.End:
+                    Position = _length + offset;
+                    break;
+                default:
+                    Throw.ArgumentOutOfRange(nameof(origin));
+                    break;
+            }
+            return Position;
+        }
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadSpan(new Span<byte>(buffer, offset, count));
+
+        public override int ReadByte()
+        {
+            Span<byte> span = stackalloc byte[1];
+            return ReadSpan(span) <= 0 ? -1 : span[0];
+        }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return Task.FromResult(Read(buffer, offset, count));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+        }
+
+        private int ReadSpan(Span<byte> buffer)
+        {
+            int bytes = (int)Math.Min(buffer.Length, _length - _position);
+            if (bytes <= 0) return 0;
+            _sequence.Slice(_position, bytes).CopyTo(buffer);
+            _position += bytes;
+            return bytes;
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            try
+            {
+                ReadOnlySequenceStream.CopyTo(_sequence.Slice(_position, _length - _position), destination);
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
+        }
+
+        public override void WriteByte(byte value)
+        {
+            ReadOnlySpan<byte> span = stackalloc byte[1] { value };
+            WriteSpan(span);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                WriteSpan(new Span<byte>(buffer, offset, count));
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
+        }
+
+        private void WriteSpan(ReadOnlySpan<byte> span)
+        {
+            if (!span.IsEmpty)
+            {
+                Expand(_position + span.Length);
+                span.CopyTo(_sequence.Slice(_position));
+                _position += span.Length;
+            }
+        }
+
+#if SOCKET_STREAM_BUFFERS
+        public override void CopyTo(Stream destination, int bufferSize)
+            => ReadOnlySequenceStream.CopyTo(_sequence.Slice(_position, _length - _position), destination);
+        public override int Read(Span<byte> buffer) => ReadSpan(buffer);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return new ValueTask<int>(ReadSpan(buffer.Span));
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+        }
+        public override void Write(ReadOnlySpan<byte> buffer) => WriteSpan(buffer);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                WriteSpan(buffer.Span);
+                return default;
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask(Task.FromException(ex));
+            }
+        }
+#endif
+    }
+
+    public sealed class ReadOnlySequenceStream : Stream
+    {
+        private readonly ReadOnlySequence<byte> _sequence;
+        private readonly long _length;
+        private long _position;
+
+        public ReadOnlySequenceStream(ReadOnlySequence<byte> sequence)
+        {
+            _sequence = sequence;
+            _length = sequence.Length;
+        }
+
+        public ReadOnlySequence<byte> GetBuffer() => _sequence;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override void Flush() { }
+        public override bool CanTimeout => false;
+        public override void Write(byte[] buffer, int offset, int count) => Throw.NotSupported();
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            Throw.NotSupported();
+            return default;
+        }
+        public override void EndWrite(IAsyncResult asyncResult)
+            => Throw.NotSupported();
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            Throw.NotSupported();
+            return default;
+        }
+        public override void WriteByte(byte value) => Throw.NotSupported();
+        public override long Position
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _position;
+            set
+            {
+                if (_position < 0 | _position > _length) Throw.ArgumentOutOfRange(nameof(Position));
+                _position = value;
+            }
+        }
+
+        public override long Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _length;
+        }
+
+        public override void SetLength(long value)
+        {
+            if (value != _length) Throw.NotSupported();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Current:
+                    Position += offset;
+                    break;
+                case SeekOrigin.Begin:
+                    Position = offset;
+                    break;
+                case SeekOrigin.End:
+                    Position = _length + offset;
+                    break;
+                default:
+                    Throw.ArgumentOutOfRange(nameof(origin));
+                    break;
+            }
+            return Position;
+        }
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadSpan(new Span<byte>(buffer, offset, count));
+
+        public override int ReadByte()
+        {
+            Span<byte> span = stackalloc byte[1];
+            return ReadSpan(span) <= 0 ? -1 : span[0];
+        }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return Task.FromResult(Read(buffer, offset, count));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+        }
+
+        private int ReadSpan(Span<byte> buffer)
+        {
+            int bytes = (int)Math.Min(buffer.Length, _length - _position);
+            if (bytes <= 0) return 0;
+            _sequence.Slice(_position, bytes).CopyTo(buffer);
+            _position += bytes;
+            return bytes;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void CopySegment(in ReadOnlyMemory<byte> buffer, Stream destination)
+        {
+#if SOCKET_STREAM_BUFFERS
+            destination.Write(buffer.Span);
+#else
+            if(MemoryMarshal.TryGetArray(buffer, out var segment))
+            {
+                destination.Write(segment.Array, segment.Offset, segment.Count);
+            }
+            else
+            {
+                var span = buffer.Span;
+                var arr = ArrayPool<byte>.Shared.Rent(span.Length);
+                span.CopyTo(arr);
+                destination.Write(arr, 0, span.Length);
+                ArrayPool<byte>.Shared.Return(arr);
+            }
+#endif
+        }
+
+        internal static void CopyTo(in ReadOnlySequence<byte> sequence, Stream destination)
+        {
+            if (sequence.IsSingleSegment)
+            {
+                CopySegment(sequence.First, destination);
+            }
+            else
+            {
+                foreach(var segment in sequence)
+                {
+                    CopySegment(segment, destination);
+                }
+            }
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            try
+            {
+                CopyTo(_sequence.Slice(_position), destination);
+                return Task.CompletedTask;
+            }
+            catch(Exception ex)
+            {
+                return Task.FromException(ex);
+            }
+        }
+
+#if SOCKET_STREAM_BUFFERS
+        public override void CopyTo(Stream destination, int bufferSize) => CopyTo(_sequence.Slice(_position), destination);
+        public override int Read(Span<byte> buffer) => ReadSpan(buffer);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return new ValueTask<int>(ReadSpan(buffer.Span));
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+        }
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Throw.NotSupported();
+            return default;
+        }
+        public override void Write(ReadOnlySpan<byte> buffer) => Throw.NotSupported();
+#endif
+    }
+}

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceStream.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceStream.cs
@@ -177,15 +177,19 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            var segment = _sequence.Start.GetObject() as LeasedSegment;
-            _sequence = default;
 
-            // now release the chain if it was leased
-            while (segment != null)
+            if (disposing)
             {
-                var next = segment.Next; // in case Dispose breaks the chain
-                try { segment.Dispose(); } catch { } // best efforts
-                segment = next;
+                var segment = _sequence.Start.GetObject() as LeasedSegment;
+                _sequence = default;
+
+                // now release the chain if it was leased
+                while (segment != null)
+                {
+                    var next = segment.Next; // in case Dispose breaks the chain
+                    try { segment.Dispose(); } catch { } // best efforts
+                    segment = next;
+                }
             }
         }
 

--- a/src/Pipelines.Sockets.Unofficial/Arenas/SequenceStream.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/SequenceStream.cs
@@ -181,8 +181,8 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         /// <summary>
         /// Create a new dynamically expandable SequenceStream
         /// </summary>
-        public static SequenceStream Create(long minCapacity = 0, long maxCapacity = long.MaxValue, MemoryPool<byte> pool = default)
-            => maxCapacity == 0 ? s_empty : new SequenceStreamImpl(minCapacity, maxCapacity, pool);
+        public static SequenceStream Create(long minCapacity = 0, long maxCapacity = long.MaxValue)
+            => maxCapacity == 0 ? s_empty : new SequenceStreamImpl(minCapacity, maxCapacity);
 
         /// <summary>
         /// Create a new SequenceStream based on an existing sequence; it will not be possible to expand the stream past the initial capacity
@@ -190,7 +190,7 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         public static SequenceStream Create(in Sequence<byte> sequence)
             => sequence.IsEmpty ? s_empty : new SequenceStreamImpl(sequence);
 
-        private static readonly SequenceStreamImpl s_empty = new SequenceStreamImpl(0, 0, null);
+        private static readonly SequenceStreamImpl s_empty = new SequenceStreamImpl(0, 0);
 
         /// <summary>
         /// Gets the underlying buffer associated with this stream
@@ -276,9 +276,9 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
         private class LeasedSegment : SequenceSegment<byte>
         {
-            internal static LeasedSegment Create(int minimumSize, LeasedSegment previous, MemoryPool<byte> pool)
+            internal static LeasedSegment Create(int minimumSize, LeasedSegment previous)
             {
-                var leased = pool.Rent(minimumSize);
+                var array = ArrayPool<byte>.Shared.Rent(minimumSize);
 #if DEBUG
                 Interlocked.Increment(ref s_leaseCount);
 #endif
@@ -294,11 +294,11 @@ namespace Pipelines.Sockets.Unofficial.Arenas
                     if (Interlocked.CompareExchange(ref s_poolHead, newHead, oldHead) == oldHead)
                     {
                         Interlocked.Decrement(ref s_poolSize); // doesn't need to be hard in lock-step with the actual length
-                        oldHead.Init(leased, previous);
+                        oldHead.Init(array, previous);
                         return oldHead;
                     }
                 }
-                return new LeasedSegment(leased, previous);
+                return new LeasedSegment(array, previous);
             }
 
             static void PushToPool(LeasedSegment segment)
@@ -322,38 +322,24 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             static LeasedSegment s_poolHead;
             static int s_poolSize;
 
-            private IMemoryOwner<byte> _lease;
-            private LeasedSegment(IMemoryOwner<byte> lease, LeasedSegment previous) : base(lease.Memory, previous)
-            {
-                _lease = lease;
-            }
-            internal void Init(IMemoryOwner<byte> lease, LeasedSegment previous)
-            {
-                Init(lease.Memory, previous);
-                _lease = lease;
-            }
+            private LeasedSegment(byte[] array, LeasedSegment previous) : base(array, previous) { }
 
             internal void CascadeRelease(bool inclusive)
             {
                 var segment = inclusive ? this : (LeasedSegment)ResetNext();
                 while (segment != null)
                 {
-                    segment.ReleaseMemory();
+                    if (MemoryMarshal.TryGetArray<byte>(segment.ResetMemory(), out var array))
+                    {
+                        ArrayPool<byte>.Shared.Return(array.Array);
 #if DEBUG
-                    Interlocked.Decrement(ref s_leaseCount);
+                        Interlocked.Decrement(ref s_leaseCount);
 #endif
+                    }
                     var next = (LeasedSegment)segment.ResetNext();
                     PushToPool(segment);
                     segment = next;
                 }
-            }
-
-            private void ReleaseMemory()
-            {
-                ResetMemory();
-                var lease = _lease;
-                _lease = null;
-                lease?.Dispose();
             }
         }
 
@@ -392,8 +378,6 @@ namespace Pipelines.Sockets.Unofficial.Arenas
                 Debug.Assert(_capacity <= _maxCapacity, "oversized capacity");
                 Debug.Assert(_length >= 0 & Length <= _capacity, "invalid length");
                 Debug.Assert(_position >= 0 & _position <= _length, "invalid position");
-                if (IsOwner) Debug.Assert(_pool != null, "expected a pool");
-                else Debug.Assert(_pool == null, "didn't expect a pool");
             }
         }
 #endif
@@ -401,11 +385,9 @@ namespace Pipelines.Sockets.Unofficial.Arenas
         private FastState _fastState;
 
         public override bool CanWrite => true;
-        private readonly MemoryPool<byte> _pool;
 
-        internal SequenceStreamImpl(long minCapacity, long maxCapacity, MemoryPool<byte> pool)
+        internal SequenceStreamImpl(long minCapacity, long maxCapacity)
         {
-            _pool = pool ?? MemoryPool<byte>.Shared;
             _flags |= (int)StreamFlags.IsOwner;
             if (minCapacity < 0) Throw.ArgumentOutOfRange(nameof(minCapacity));
             if (maxCapacity < minCapacity) Throw.ArgumentOutOfRange(nameof(maxCapacity));
@@ -497,18 +479,18 @@ namespace Pipelines.Sockets.Unofficial.Arenas
             var head = GetLeaseHead();
             var tail = GetLeaseTail();
 
-            const int MinBlockSize = 1024;
+            const int MinBlockSize = 1024, MaxBlockSize = 256 * 1024;
 
             long needed = length - _capacity;
             Debug.Assert(needed > 0, "expected to grow capacity");
 
-            int takeFromTail = -1, maxBlockSize = Math.Max(256 * 1024, _pool.MaxBufferSize);
+            int takeFromTail = -1;
             while (needed > 0)
             {
                 int delta;
-                if (needed >= maxBlockSize | _capacity >= maxBlockSize)
+                if (needed >= MaxBlockSize | _capacity >= MaxBlockSize)
                 {   // nice and simple
-                    delta = maxBlockSize;
+                    delta = MaxBlockSize;
                 }
                 else
                 {
@@ -528,7 +510,7 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
                 if (delta <= 0) Throw.InvalidOperation("Error expanding chain");
 
-                tail = LeasedSegment.Create(delta, tail, _pool);
+                tail = LeasedSegment.Create(delta, tail);
                 if (head == null) head = tail;
 
                 // note: we might not want to take all of what we are given, because of max-capacity

--- a/src/Pipelines.Sockets.Unofficial/DedicatedThreadPoolPipeScheduler.cs
+++ b/src/Pipelines.Sockets.Unofficial/DedicatedThreadPoolPipeScheduler.cs
@@ -114,6 +114,14 @@ namespace Pipelines.Sockets.Unofficial
         }
 
         /// <summary>
+        /// Get the number of pending work items in the queue
+        /// </summary>
+        public int PendingWorkItemCount
+        {
+            get { lock (_queue) { return _queue.Count; } }
+        }
+
+        /// <summary>
         /// Requests <paramref name="action"/> to be run on scheduler with <paramref name="state"/> being passed in
         /// </summary>
         public override void Schedule(Action<object> action, object state)

--- a/src/Pipelines.Sockets.Unofficial/Pipelines.Sockets.Unofficial.csproj
+++ b/src/Pipelines.Sockets.Unofficial/Pipelines.Sockets.Unofficial.csproj
@@ -22,6 +22,9 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);SOCKET_STREAM_BUFFERS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.2'">
+    <DefineConstants>$(DefineConstants);SOCKET_STREAM_BUFFERS</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
     <DefineConstants>$(DefineConstants);SOCKET_STREAM_BUFFERS</DefineConstants><!--;RANGES-->
   </PropertyGroup>

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -9,6 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0-pre-05" />
     <ProjectReference Include="..\..\src\Pipelines.Sockets.Unofficial\Pipelines.Sockets.Unofficial.csproj" />
   </ItemGroup>

--- a/tests/Benchmark/ListBenchmarks.cs
+++ b/tests/Benchmark/ListBenchmarks.cs
@@ -51,6 +51,28 @@ namespace Benchmark
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
+        //[Benchmark]
+        //public int SeqeunceListDefault_Int32_Appender()
+        //{
+        //    var list = SequenceList<int>.Create();
+        //    var appender = list.GetAppender();
+        //    for (int i = 0; i < SIZE; i++)
+        //        appender.Add(_value32);
+        //    int count = list.Count;
+        //    list.Clear(trim: true);
+        //    return count.AssertIs(SIZE);
+        //}
+        //[Benchmark]
+        //public int SeqeunceListPresized_Int32_Appender()
+        //{
+        //    var list = SequenceList<int>.Create(SIZE);
+        //    var appender = list.GetAppender();
+        //    for (int i = 0; i < SIZE; i++)
+        //        appender.Add(_value32);
+        //    int count = list.Count;
+        //    list.Clear(trim: true);
+        //    return count.AssertIs(SIZE);
+        //}
 
         private int _value32;
         private long _value64;
@@ -91,5 +113,27 @@ namespace Benchmark
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
+        //[Benchmark]
+        //public int SeqeunceListDefault_Int64_Appender()
+        //{
+        //    var list = SequenceList<long>.Create();
+        //    var appender = list.GetAppender();
+        //    for (int i = 0; i < SIZE; i++)
+        //        appender.Add(_value64);
+        //    int count = list.Count;
+        //    list.Clear(trim: true);
+        //    return count.AssertIs(SIZE);
+        //}
+        //[Benchmark]
+        //public int SeqeunceListPresized_Int64_Appender()
+        //{
+        //    var list = SequenceList<long>.Create(SIZE);
+        //    var appender = list.GetAppender();
+        //    for (int i = 0; i < SIZE; i++)
+        //        appender.Add(_value64);
+        //    int count = list.Count;
+        //    list.Clear(trim: true);
+        //    return count.AssertIs(SIZE);
+        //}
     }
 }

--- a/tests/Benchmark/ListBenchmarks.cs
+++ b/tests/Benchmark/ListBenchmarks.cs
@@ -1,0 +1,95 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pipelines.Sockets.Unofficial.Arenas;
+using System.Collections.Generic;
+
+namespace Benchmark
+{
+    [MemoryDiagnoser, CoreJob, ClrJob, MinColumn, MaxColumn]
+    public class ListBenchmarks : BenchmarkBase
+    {
+        public ListBenchmarks()
+        {
+            _value32 = 42;
+            _value64 = 42;
+        }
+
+        const int SIZE = 1024;
+
+        [Benchmark]
+        public int ListDefault_Int32()
+        {
+            var list = new List<int>();
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value32);
+            return list.Count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int ListPresized_Int32()
+        {
+            var list = new List<int>(SIZE);
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value32);
+            return list.Count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int SeqeunceListDefault_Int32()
+        {
+            var list = SequenceList<int>.Create();
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value32);
+            int count = list.Count;
+            list.Clear(trim: true);
+            return count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int SeqeunceListPresized_Int32()
+        {
+            var list = SequenceList<int>.Create(SIZE);
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value32);
+            int count = list.Count;
+            list.Clear(trim: true);
+            return count.AssertIs(SIZE);
+        }
+
+        private int _value32;
+        private long _value64;
+
+        [Benchmark]
+        public int ListDefault_Int64()
+        {
+            var list = new List<long>();
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value64);
+            return list.Count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int ListPresized_Int64()
+        {
+            var list = new List<long>(SIZE);
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value64);
+            return list.Count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int SeqeunceListDefault_Int64()
+        {
+            var list = SequenceList<long>.Create();
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value64);
+            int count = list.Count;
+            list.Clear(trim: true);
+            return count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int SeqeunceListPresized_Int64()
+        {
+            var list = SequenceList<long>.Create(SIZE);
+            for (int i = 0; i < SIZE; i++)
+                list.Add(_value64);
+            int count = list.Count;
+            list.Clear(trim: true);
+            return count.AssertIs(SIZE);
+        }
+    }
+}

--- a/tests/Benchmark/ListBenchmarks.cs
+++ b/tests/Benchmark/ListBenchmarks.cs
@@ -1,92 +1,81 @@
 ﻿using BenchmarkDotNet.Attributes;
 using Pipelines.Sockets.Unofficial.Arenas;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Benchmark
 {
     [MemoryDiagnoser, CoreJob, ClrJob, MinColumn, MaxColumn]
     public class ListBenchmarks : BenchmarkBase
     {
-        public ListBenchmarks()
-        {
-            _value32 = 42;
-            _value64 = 42;
-        }
-
         const int SIZE = 1024;
 
         [Benchmark]
-        public int ListDefault_Int32()
+        public int ListDefault_Add()
         {
             var list = new List<int>();
             for (int i = 0; i < SIZE; i++)
-                list.Add(_value32);
+                list.Add(i);
             return list.Count.AssertIs(SIZE);
         }
         [Benchmark]
-        public int ListPresized_Int32()
+        public int ListPresized_Add()
         {
             var list = new List<int>(SIZE);
             for (int i = 0; i < SIZE; i++)
-                list.Add(_value32);
+                list.Add(i);
+            return list.Count.AssertIs(SIZE);
+        }
+
+        [Benchmark]
+        public int ListDefault_AddRange()
+        {
+            var list = new List<int>();
+            list.AddRange(Enumerable.Range(0, SIZE));
             return list.Count.AssertIs(SIZE);
         }
         [Benchmark]
-        public int SeqeunceListDefault_Int32()
+        public int ListPresized_AddRange()
+        {
+            var list = new List<int>(SIZE);
+            list.AddRange(Enumerable.Range(0, SIZE));
+            return list.Count.AssertIs(SIZE);
+        }
+        [Benchmark]
+        public int SequenceListDefault_Add()
         {
             var list = SequenceList<int>.Create();
             for (int i = 0; i < SIZE; i++)
-                list.Add(_value32);
+                list.Add(i);
             int count = list.Count;
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
         [Benchmark]
-        public int SeqeunceListPresized_Int32()
+        public int SequenceListPresized_Add()
         {
             var list = SequenceList<int>.Create(SIZE);
             for (int i = 0; i < SIZE; i++)
-                list.Add(_value32);
+                list.Add(i);
             int count = list.Count;
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
 
-        private int _value32;
-        private long _value64;
-
         [Benchmark]
-        public int ListDefault_Int64()
+        public int SequenceListDefault_AddRange()
         {
-            var list = new List<long>();
-            for (int i = 0; i < SIZE; i++)
-                list.Add(_value64);
-            return list.Count.AssertIs(SIZE);
-        }
-        [Benchmark]
-        public int ListPresized_Int64()
-        {
-            var list = new List<long>(SIZE);
-            for (int i = 0; i < SIZE; i++)
-                list.Add(_value64);
-            return list.Count.AssertIs(SIZE);
-        }
-        [Benchmark]
-        public int SeqeunceListDefault_Int64()
-        {
-            var list = SequenceList<long>.Create();
-            for (int i = 0; i < SIZE; i++)
-                list.Add(_value64);
+            var list = SequenceList<int>.Create();
+            list.AddRange(Enumerable.Range(0, SIZE));
             int count = list.Count;
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
         [Benchmark]
-        public int SeqeunceListPresized_Int64()
+        public int SequenceListPresized_AddRange()
         {
-            var list = SequenceList<long>.Create(SIZE);
-            for (int i = 0; i < SIZE; i++)
-                list.Add(_value64);
+            var list = SequenceList<int>.Create(SIZE);
+            list.AddRange(Enumerable.Range(0, SIZE));
             int count = list.Count;
             list.Clear(trim: true);
             return count.AssertIs(SIZE);

--- a/tests/Benchmark/ListBenchmarks.cs
+++ b/tests/Benchmark/ListBenchmarks.cs
@@ -51,28 +51,6 @@ namespace Benchmark
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
-        //[Benchmark]
-        //public int SeqeunceListDefault_Int32_Appender()
-        //{
-        //    var list = SequenceList<int>.Create();
-        //    var appender = list.GetAppender();
-        //    for (int i = 0; i < SIZE; i++)
-        //        appender.Add(_value32);
-        //    int count = list.Count;
-        //    list.Clear(trim: true);
-        //    return count.AssertIs(SIZE);
-        //}
-        //[Benchmark]
-        //public int SeqeunceListPresized_Int32_Appender()
-        //{
-        //    var list = SequenceList<int>.Create(SIZE);
-        //    var appender = list.GetAppender();
-        //    for (int i = 0; i < SIZE; i++)
-        //        appender.Add(_value32);
-        //    int count = list.Count;
-        //    list.Clear(trim: true);
-        //    return count.AssertIs(SIZE);
-        //}
 
         private int _value32;
         private long _value64;
@@ -113,27 +91,5 @@ namespace Benchmark
             list.Clear(trim: true);
             return count.AssertIs(SIZE);
         }
-        //[Benchmark]
-        //public int SeqeunceListDefault_Int64_Appender()
-        //{
-        //    var list = SequenceList<long>.Create();
-        //    var appender = list.GetAppender();
-        //    for (int i = 0; i < SIZE; i++)
-        //        appender.Add(_value64);
-        //    int count = list.Count;
-        //    list.Clear(trim: true);
-        //    return count.AssertIs(SIZE);
-        //}
-        //[Benchmark]
-        //public int SeqeunceListPresized_Int64_Appender()
-        //{
-        //    var list = SequenceList<long>.Create(SIZE);
-        //    var appender = list.GetAppender();
-        //    for (int i = 0; i < SIZE; i++)
-        //        appender.Add(_value64);
-        //    int count = list.Count;
-        //    list.Clear(trim: true);
-        //    return count.AssertIs(SIZE);
-        //}
     }
 }

--- a/tests/Benchmark/StreamBenchmarks.cs
+++ b/tests/Benchmark/StreamBenchmarks.cs
@@ -44,6 +44,7 @@ namespace Benchmark
             }
         }
 
+        [Benchmark]
         public long RecyclableMemoryStreamDefault()
         {
             using (var ms = new RecyclableMemoryStream(manager, "tag"))

--- a/tests/Benchmark/StreamBenchmarks.cs
+++ b/tests/Benchmark/StreamBenchmarks.cs
@@ -1,0 +1,73 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pipelines.Sockets.Unofficial.Arenas;
+using System;
+using System.IO;
+
+namespace Benchmark
+{
+
+    public class StreamBenchmarks : BenchmarkBase
+    {
+        const int SEED = 123456, MAX_BYTES = 2048, ITERS = 512, TOTAL_SIZE = 514672;
+        private readonly byte[] buffer = new byte[MAX_BYTES];
+        [Benchmark(Baseline = true)]
+        public long MemoryStreamDefault()
+        {
+            using (var ms = new MemoryStream())
+            {
+                var rand = new Random(SEED);
+                for (int i = 0; i < ITERS; i++)
+                {
+                    rand.NextBytes(buffer);
+                    ms.Write(buffer, 0, rand.Next(MAX_BYTES));
+                }
+                return ms.Length.AssertIs(TOTAL_SIZE);
+            }
+        }
+
+        [Benchmark]
+        public long MemoryStreamPreSize()
+        {
+            using (var ms = new MemoryStream(TOTAL_SIZE))
+            {
+                var rand = new Random(SEED);
+                for (int i = 0; i < ITERS; i++)
+                {
+                    rand.NextBytes(buffer);
+                    ms.Write(buffer, 0, rand.Next(MAX_BYTES));
+                }
+                return ms.Length.AssertIs(TOTAL_SIZE);
+            }
+        }
+
+        [Benchmark]
+        public long SequenceStreamDefault()
+        {
+            using (var ms = SequenceStream.Create())
+            {
+                var rand = new Random(SEED);
+                for (int i = 0; i < ITERS; i++)
+                {
+                    rand.NextBytes(buffer);
+                    ms.Write(buffer, 0, rand.Next(MAX_BYTES));
+                }
+                return ms.Length.AssertIs(TOTAL_SIZE);
+            }
+        }
+
+        [Benchmark]
+        public long SequenceStreamPreSize()
+        {
+            using (var ms = SequenceStream.Create(TOTAL_SIZE))
+            {
+                var rand = new Random(SEED);
+                for (int i = 0; i < ITERS; i++)
+                {
+                    rand.NextBytes(buffer);
+                    ms.Write(buffer, 0, rand.Next(MAX_BYTES));
+                }
+                return ms.Length.AssertIs(TOTAL_SIZE);
+            }
+        }
+    }
+}

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -150,9 +150,13 @@ namespace Pipelines.Sockets.Unofficial.Tests
         [Fact] public Task ListPresized_Int32() => Run(_ => _.ListPresized_Int32());
         [Fact] public Task SeqeunceListDefault_Int32() => Run(_ => _.SeqeunceListDefault_Int32());
         [Fact] public Task SeqeunceListPresized_Int32() => Run(_ => _.SeqeunceListPresized_Int32());
+        //[Fact] public Task SeqeunceListDefault_Int32_Appender() => Run(_ => _.SeqeunceListDefault_Int32_Appender());
+        //[Fact] public Task SeqeunceListPresized_Int32_Appender() => Run(_ => _.SeqeunceListPresized_Int32_Appender());
         [Fact] public Task ListDefault_Int64() => Run(_ => _.ListDefault_Int64());
         [Fact] public Task ListPresized_Int64() => Run(_ => _.ListPresized_Int64());
         [Fact] public Task SeqeunceListDefault_Int64() => Run(_ => _.SeqeunceListDefault_Int64());
         [Fact] public Task SeqeunceListPresized_Int64() => Run(_ => _.SeqeunceListPresized_Int64());
+        //[Fact] public Task SeqeunceListDefault_Int64_Appender() => Run(_ => _.SeqeunceListDefault_Int64_Appender());
+        //[Fact] public Task SeqeunceListPresized_Int64_Appender() => Run(_ => _.SeqeunceListPresized_Int64_Appender());
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -130,4 +130,13 @@ namespace Pipelines.Sockets.Unofficial.Tests
         [Fact] public Task SemaphoreSlim_ConcurrentLoadAsync() => Run(_ => _.SemaphoreSlim_ConcurrentLoadAsync());
         [Fact] public Task SemaphoreSlim_Sync() => Run(_ => _.SemaphoreSlim_Sync());
     }
+
+    public class StreamBenchmarkTests : BenchmarkTests<StreamBenchmarks>
+    {
+        public StreamBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
+        [Fact] public Task MemoryStreamDefault() => Run(_ => _.MemoryStreamDefault());
+        [Fact] public Task MemoryStreamPreSize() => Run(_ => _.MemoryStreamPreSize());
+        [Fact] public Task SequenceStreamDefault() => Run(_ => _.SequenceStreamDefault());
+        [Fact] public Task SequenceStreamPreSize() => Run(_ => _.SequenceStreamPreSize());
+    }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -146,13 +146,13 @@ namespace Pipelines.Sockets.Unofficial.Tests
     {
         public ListBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
 
-        [Fact] public Task ListDefault_Int32() => Run(_ => _.ListDefault_Int32());
-        [Fact] public Task ListPresized_Int32() => Run(_ => _.ListPresized_Int32());
-        [Fact] public Task SeqeunceListDefault_Int32() => Run(_ => _.SeqeunceListDefault_Int32());
-        [Fact] public Task SeqeunceListPresized_Int32() => Run(_ => _.SeqeunceListPresized_Int32());
-        [Fact] public Task ListDefault_Int64() => Run(_ => _.ListDefault_Int64());
-        [Fact] public Task ListPresized_Int64() => Run(_ => _.ListPresized_Int64());
-        [Fact] public Task SeqeunceListDefault_Int64() => Run(_ => _.SeqeunceListDefault_Int64());
-        [Fact] public Task SeqeunceListPresized_Int64() => Run(_ => _.SeqeunceListPresized_Int64());
+        [Fact] public Task ListDefault_Add() => Run(_ => _.ListDefault_Add());
+        [Fact] public Task ListPresized_Add() => Run(_ => _.ListPresized_Add());
+        [Fact] public Task ListDefault_AddRange() => Run(_ => _.ListDefault_AddRange());
+        [Fact] public Task ListPresized_AddRange() => Run(_ => _.ListPresized_AddRange());
+        [Fact] public Task SequenceListDefault_Add() => Run(_ => _.SequenceListDefault_Add());
+        [Fact] public Task SequenceListPresized_Add() => Run(_ => _.SequenceListPresized_Add());
+        [Fact] public Task SequenceListDefault_AddRange() => Run(_ => _.SequenceListDefault_AddRange());
+        [Fact] public Task SequenceListPresized_AddRange() => Run(_ => _.SequenceListPresized_AddRange());
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -136,6 +136,8 @@ namespace Pipelines.Sockets.Unofficial.Tests
         public StreamBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
         [Fact] public Task MemoryStreamDefault() => Run(_ => _.MemoryStreamDefault());
         [Fact] public Task MemoryStreamPreSize() => Run(_ => _.MemoryStreamPreSize());
+        [Fact] public Task RecyclableMemoryStreamDefault() => Run(_ => _.RecyclableMemoryStreamDefault());
+        [Fact] public Task RecyclableMemoryStreamPreSize() => Run(_ => _.RecyclableMemoryStreamPreSize());
         [Fact] public Task SequenceStreamDefault() => Run(_ => _.SequenceStreamDefault());
         [Fact] public Task SequenceStreamPreSize() => Run(_ => _.SequenceStreamPreSize());
     }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -141,4 +141,18 @@ namespace Pipelines.Sockets.Unofficial.Tests
         [Fact] public Task SequenceStreamDefault() => Run(_ => _.SequenceStreamDefault());
         [Fact] public Task SequenceStreamPreSize() => Run(_ => _.SequenceStreamPreSize());
     }
+
+    public class ListBenchmarkTests : BenchmarkTests<ListBenchmarks>
+    {
+        public ListBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
+
+        [Fact] public Task ListDefault_Int32() => Run(_ => _.ListDefault_Int32());
+        [Fact] public Task ListPresized_Int32() => Run(_ => _.ListPresized_Int32());
+        [Fact] public Task SeqeunceListDefault_Int32() => Run(_ => _.SeqeunceListDefault_Int32());
+        [Fact] public Task SeqeunceListPresized_Int32() => Run(_ => _.SeqeunceListPresized_Int32());
+        [Fact] public Task ListDefault_Int64() => Run(_ => _.ListDefault_Int64());
+        [Fact] public Task ListPresized_Int64() => Run(_ => _.ListPresized_Int64());
+        [Fact] public Task SeqeunceListDefault_Int64() => Run(_ => _.SeqeunceListDefault_Int64());
+        [Fact] public Task SeqeunceListPresized_Int64() => Run(_ => _.SeqeunceListPresized_Int64());
+    }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -150,13 +150,9 @@ namespace Pipelines.Sockets.Unofficial.Tests
         [Fact] public Task ListPresized_Int32() => Run(_ => _.ListPresized_Int32());
         [Fact] public Task SeqeunceListDefault_Int32() => Run(_ => _.SeqeunceListDefault_Int32());
         [Fact] public Task SeqeunceListPresized_Int32() => Run(_ => _.SeqeunceListPresized_Int32());
-        //[Fact] public Task SeqeunceListDefault_Int32_Appender() => Run(_ => _.SeqeunceListDefault_Int32_Appender());
-        //[Fact] public Task SeqeunceListPresized_Int32_Appender() => Run(_ => _.SeqeunceListPresized_Int32_Appender());
         [Fact] public Task ListDefault_Int64() => Run(_ => _.ListDefault_Int64());
         [Fact] public Task ListPresized_Int64() => Run(_ => _.ListPresized_Int64());
         [Fact] public Task SeqeunceListDefault_Int64() => Run(_ => _.SeqeunceListDefault_Int64());
         [Fact] public Task SeqeunceListPresized_Int64() => Run(_ => _.SeqeunceListPresized_Int64());
-        //[Fact] public Task SeqeunceListDefault_Int64_Appender() => Run(_ => _.SeqeunceListDefault_Int64_Appender());
-        //[Fact] public Task SeqeunceListPresized_Int64_Appender() => Run(_ => _.SeqeunceListPresized_Int64_Appender());
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/ListTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/ListTests.cs
@@ -28,5 +28,30 @@ namespace Pipelines.Sockets.Unofficial.Tests
                 Assert.Equal(i, list[i]);
             }
         }
+
+        //[Fact]
+        //public void CanUseListsViaAppender()
+        //{
+        //    var list = SequenceList<int>.Create(200);
+        //    var appender = list.GetAppender();
+        //    for (int i = 0; i < 200; i++)
+        //    {
+        //        Assert.Equal(i, list.Count);
+        //        Assert.Equal(200, list.Capacity);
+        //        appender.Add(i);
+        //    }
+        //    Assert.Equal(200, list.Count);
+        //    Assert.Equal(200, list.Capacity);
+
+        //    int j = 0;
+        //    foreach (var item in list)
+        //    {
+        //        Assert.Equal(j++, item);
+        //    }
+        //    for (int i = 0; i < 200; i++)
+        //    {
+        //        Assert.Equal(i, list[i]);
+        //    }
+        //}
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/ListTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/ListTests.cs
@@ -28,30 +28,5 @@ namespace Pipelines.Sockets.Unofficial.Tests
                 Assert.Equal(i, list[i]);
             }
         }
-
-        //[Fact]
-        //public void CanUseListsViaAppender()
-        //{
-        //    var list = SequenceList<int>.Create(200);
-        //    var appender = list.GetAppender();
-        //    for (int i = 0; i < 200; i++)
-        //    {
-        //        Assert.Equal(i, list.Count);
-        //        Assert.Equal(200, list.Capacity);
-        //        appender.Add(i);
-        //    }
-        //    Assert.Equal(200, list.Count);
-        //    Assert.Equal(200, list.Capacity);
-
-        //    int j = 0;
-        //    foreach (var item in list)
-        //    {
-        //        Assert.Equal(j++, item);
-        //    }
-        //    for (int i = 0; i < 200; i++)
-        //    {
-        //        Assert.Equal(i, list[i]);
-        //    }
-        //}
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/ListTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/ListTests.cs
@@ -1,0 +1,32 @@
+﻿using Pipelines.Sockets.Unofficial.Arenas;
+using Xunit;
+
+namespace Pipelines.Sockets.Unofficial.Tests
+{
+    public class ListTests
+    {
+        [Fact]
+        public void CanUseLists()
+        {
+            var list = SequenceList<int>.Create(200);
+            for (int i = 0; i < 200; i++)
+            {
+                Assert.Equal(i, list.Count);
+                Assert.Equal(200, list.Capacity);
+                list.Add(i);
+            }
+            Assert.Equal(200, list.Count);
+            Assert.Equal(200, list.Capacity);
+
+            int j = 0;
+            foreach(var item in list)
+            {
+                Assert.Equal(j++, item);
+            }
+            for(int i = 0; i < 200;i++)
+            {
+                Assert.Equal(i, list[i]);
+            }
+        }
+    }
+}

--- a/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="..\Benchmark\ArenaBenchmarks.cs" />
     <Compile Include="..\Benchmark\LockBenchmarks.cs" />
+    <Compile Include="..\Benchmark\StreamBenchmarks.cs" />
     <Compile Include="..\Benchmark\Utils.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\Benchmark\ArenaBenchmarks.cs" />
     <Compile Include="..\Benchmark\LockBenchmarks.cs" />
     <Compile Include="..\Benchmark\StreamBenchmarks.cs" />
+    <Compile Include="..\Benchmark\ListBenchmarks.cs" />
     <Compile Include="..\Benchmark\Utils.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />

--- a/tests/Pipelines.Sockets.Unofficial.Tests/SequenceTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/SequenceTests.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Buffers;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Pipelines.Sockets.Unofficial.Tests

--- a/tests/Pipelines.Sockets.Unofficial.Tests/StreamTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/StreamTests.cs
@@ -7,6 +7,10 @@ using Xunit;
 
 namespace Pipelines.Sockets.Unofficial.Tests
 {
+    [CollectionDefinition(nameof(NonParallelCollectionDefinition), DisableParallelization = true)]
+    public class NonParallelCollectionDefinition { }
+
+    [Collection(nameof(NonParallelCollectionDefinition))]
     public class StreamTests
     {
         [Fact]

--- a/tests/Pipelines.Sockets.Unofficial.Tests/StreamTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/StreamTests.cs
@@ -1,0 +1,154 @@
+﻿using Pipelines.Sockets.Unofficial.Arenas;
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace Pipelines.Sockets.Unofficial.Tests
+{
+    public class StreamTests
+    {
+        [Fact]
+        public void CanCreateDynamicStream()
+        {
+            const int seed = 123134;
+
+#if DEBUG
+            Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+            using (var s = SequenceStream.Create())
+            {
+                byte[] buffer = new byte[512];
+                var rand = new Random(seed);
+                long length = 0;
+                for (int i = 0; i < 1000; i++)
+                {
+                    for (int j = 0; j < buffer.Length; j++)
+                        buffer[j] = (byte)rand.Next(0, 256);
+                    s.Write(buffer, 0, buffer.Length);
+
+                    length += buffer.Length;
+                    Assert.Equal(length, s.Length);
+                    Assert.Equal(length, s.Position);
+                }
+                
+                rand = new Random(seed);
+                foreach (byte b in s.GetBuffer())
+                {
+                    Assert.Equal((byte)rand.Next(0, 256), b);
+                }
+
+                s.Position = length = 0;
+                rand = new Random(seed);                
+                int x;
+                while((x = s.ReadByte()) >= 0)
+                {
+                    Assert.Equal((byte)rand.Next(0, 256), (byte)x);
+                    Assert.Equal(++length, s.Position);
+                }
+
+#if DEBUG
+                Assert.NotEqual(0, SequenceStream.LeaseCount);
+#endif
+            }
+
+#if DEBUG
+            Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+        }
+
+        [Fact]
+        public void CanCreateReadWriteStreamFromExisting()
+        {
+            using (var arena = new Arena<byte>())
+            {
+                var bytes = arena.Allocate(1024);
+                const int seed = 123134;
+                var rand = new Random(seed);
+                foreach (ref byte b in bytes)
+                    b = (byte)rand.Next(0, 256);
+
+#if DEBUG
+                Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+                using (var s = SequenceStream.Create(bytes))
+                {
+#if DEBUG
+                    Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+                    Assert.Equal(bytes.Length, s.Length);
+                    Assert.Equal(0, s.Position);
+
+                    rand = new Random(seed);
+                    int x, length = 0;
+                    while ((x = s.ReadByte()) >= 0)
+                    {
+                        Assert.Equal((byte)rand.Next(0, 256), (byte)x);
+                        Assert.Equal(++length, s.Position);
+                    }
+
+                    Assert.Throws<InvalidOperationException>(() => s.SetLength(1025));
+
+                    s.SetLength(1024);
+                    Assert.Equal(1024, s.Length);
+
+                    bytes[1023] = 42;
+                    s.Position = 1023;
+                    Assert.Equal(42, s.ReadByte());
+                    Assert.Equal(1024, s.Position);
+
+                    s.SetLength(1023);
+                    Assert.Equal(1023, s.Length);
+                    Assert.Equal(1023, s.Position);
+
+                    Assert.Equal(42, bytes[1023]);
+                    s.SetLength(1024); // this is fine (doesn't exceed original range), but: should wipe
+                    Assert.Equal(0, bytes[1023]);
+                }
+#if DEBUG
+                Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+            }
+        }
+
+        [Fact]
+        public void CanCreateReadOnlyStreamFromExisting()
+        {
+            using (var arena = new Arena<byte>())
+            {
+                var bytes = arena.Allocate(1024);
+                const int seed = 123134;
+                var rand = new Random(seed);
+                foreach (ref byte b in bytes)
+                    b = (byte)rand.Next(0, 256);
+
+#if DEBUG
+                Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+                ReadOnlySequence<byte> ros = bytes;
+                using (var s = ReadOnlySequenceStream.Create(ros))
+                {
+#if DEBUG
+                    Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+                    Assert.Equal(bytes.Length, s.Length);
+                    Assert.Equal(0, s.Position);
+
+                    rand = new Random(seed);
+                    int x, length = 0;
+                    while ((x = s.ReadByte()) >= 0)
+                    {
+                        Assert.Equal((byte)rand.Next(0, 256), (byte)x);
+                        Assert.Equal(++length, s.Position);
+                    }
+
+                    Assert.Throws<NotSupportedException>(() => s.SetLength(1023));
+                    s.SetLength(1024);
+                    Assert.Equal(1024, s.Length);
+                }
+#if DEBUG
+                Assert.Equal(0, SequenceStream.LeaseCount);
+#endif
+            }
+        }
+    }
+}

--- a/tests/Pipelines.Sockets.Unofficial.Tests/StreamTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/StreamTests.cs
@@ -1,6 +1,7 @@
 ﻿using Pipelines.Sockets.Unofficial.Arenas;
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -43,8 +44,11 @@ namespace Pipelines.Sockets.Unofficial.Tests
                 int x;
                 while((x = s.ReadByte()) >= 0)
                 {
-                    Assert.Equal((byte)rand.Next(0, 256), (byte)x);
+                    byte expected = (byte)rand.Next(0, 256), actual = (byte)x;
+                    Assert.Equal(expected, actual);
                     Assert.Equal(++length, s.Position);
+
+                    if (s.Position == 1025) Debugger.Break();
                 }
 
                 Assert.Equal(614400, s.Length);


### PR DESCRIPTION
Adds a new `SequenceStream` / `ReadOnlySequenceStream` pair - similar to `MemoryStream`, but:

- `GetBuffer()` returns `[ReadOnly]Sequence<byte>`
- when created as dynamically resizeable, it leases segments from the `ArrayPool<byte>.Shared` and returns them when trimmed/disposed

Benefits:

- buffer allocations are pooled leases
- because non-contiguous memory is the norm, there's no need to copy any data around when expanding the underlying buffer (in this use-case, `SequenceStream` owns the sequence, so it can play with the chain; it *does not* mutate the chain if an existing one is passed in)
- allows you to treat a `Sequence<byte>` or `ReadOnlySequence<byte>` as a `Stream` with very low overhead
- (marginally) out-performs `MemoryStream` *anyway* (I'd have settled for "equal or slightly worse")

Possible additions:

- should we allow a specific `ArrayPool<byte>` to be specified? or is that unnecessary?
- if so, should we actually be exposing/using `MemoryPool<byte>[.Shared]` instead of `ArrayPool<byte>`?
- should we allow arena-based allocation as an optional opt-in?

Performance:

```
BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17134.648 (1803/April2018Update/Redstone4)
Intel Core i7-5930K CPU 3.50GHz (Broadwell), 1 CPU, 12 logical and 6 physical cores
Frequency=3416973 Hz, Resolution=292.6567 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3362.0
  Job-FQKGZY : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3362.0
  Job-UGUEYK : .NET Core 2.2.2 (CoreCLR 4.6.27317.07, CoreFX 4.6.27318.02), 64bit RyuJIT
```

|                        Method | Runtime |     Toolchain |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------ |-------- |-------------- |---------:|----------:|----------:|---------:|------:|--------:|------------:|------------:|------------:|--------------------:|
|           MemoryStreamDefault |     Clr |        net472 | 8.933 ms | 0.1760 ms | 0.3515 ms | 9.013 ms |  1.07 |    0.05 |    390.6250 |    390.6250 |    390.6250 |           1399112 B |
|           MemoryStreamPreSize |     Clr |        net472 | 8.263 ms | 0.1633 ms | 0.3480 ms | 8.466 ms |  1.00 |    0.04 |    140.6250 |    140.6250 |    140.6250 |            515976 B |
| RecyclableMemoryStreamDefault |     Clr |        net472 | 7.570 ms | 0.0628 ms | 0.0491 ms | 7.552 ms |  0.92 |    0.01 |           - |           - |           - |              1024 B |
| RecyclableMemoryStreamPreSize |     Clr |        net472 | 7.899 ms | 0.1538 ms | 0.2206 ms | 7.903 ms |  0.95 |    0.03 |           - |           - |           - |               960 B |
|         SequenceStreamDefault |     Clr |        net472 | 7.863 ms | 0.1568 ms | 0.1743 ms | 7.797 ms |  0.96 |    0.02 |           - |           - |           - |               448 B |
|         SequenceStreamPreSize |     Clr |        net472 | 8.606 ms | 0.2415 ms | 0.7120 ms | 8.407 ms |  0.98 |    0.04 |           - |           - |           - |               512 B |
|           MemoryStreamDefault |    Core | netcoreapp2.2 | 8.234 ms | 0.1316 ms | 0.1167 ms | 8.193 ms |  1.00 |    0.00 |    390.6250 |    390.6250 |    390.6250 |           1397576 B |
|           MemoryStreamPreSize |    Core | netcoreapp2.2 | 8.250 ms | 0.1647 ms | 0.2927 ms | 8.199 ms |  1.01 |    0.04 |    140.6250 |    140.6250 |    140.6250 |            515048 B |
| RecyclableMemoryStreamDefault |    Core | netcoreapp2.2 | 7.999 ms | 0.1564 ms | 0.2389 ms | 8.036 ms |  0.97 |    0.04 |           - |           - |           - |               920 B |
| RecyclableMemoryStreamPreSize |    Core | netcoreapp2.2 | 7.888 ms | 0.1541 ms | 0.2575 ms | 7.861 ms |  0.97 |    0.03 |           - |           - |           - |               920 B |
|         SequenceStreamDefault |    Core | netcoreapp2.2 | 8.282 ms | 0.1627 ms | 0.3359 ms | 8.334 ms |  1.00 |    0.05 |           - |           - |           - |               400 B |
|         SequenceStreamPreSize |    Core | netcoreapp2.2 | 8.227 ms | 0.1629 ms | 0.3364 ms | 8.253 ms |  1.01 |    0.03 |           - |           - |           - |               400 B |