### PR TITLE
Alloc free delegates

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## unreleased
+
+- add API to iterate multi-cast delegates without allocating
+
 ## 2.0.20
 
 - performance: improve high-congestion performance of Wait and improve low-congestion performance of WaitAsync (both paths now try spin-wait on first competitor **only**)

--- a/src/Pipelines.Sockets.Unofficial/Delegates.cs
+++ b/src/Pipelines.Sockets.Unofficial/Delegates.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace Pipelines.Sockets.Unofficial
+{
+    /// <summary>
+    /// Provides utility methods for working with delegates
+    /// </summary>
+    public static class Delegates
+    {
+        /// <summary>
+        /// Iterate over the individual elements of a multicast delegate (without allocation)
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DelegateEnumerator<T> GetEnumerator<T>(this T handler) where T : MulticastDelegate
+            => handler == null ? default : new DelegateEnumerator<T>(handler);
+
+        /// <summary>
+        /// Iterate over the individual elements of a multicast delegate (without allocation)
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DelegateEnumerable<T> AsEnumerable<T>(this T handler) where T : MulticastDelegate
+            => new DelegateEnumerable<T>(handler);
+
+        private static readonly Func<MulticastDelegate, object> _getArr = GetGetter<object>("_invocationList");
+        private static readonly Func<MulticastDelegate, IntPtr> _getCount = GetGetter<IntPtr>("_invocationCount");
+        private static readonly bool _isOptimized = _getArr != null & _getCount != null;
+
+        internal static bool IsOptimized => _isOptimized;
+
+        private static Func<MulticastDelegate, T> GetGetter<T>(string fieldName)
+        {
+            try
+            {
+                var field = typeof(MulticastDelegate).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+                if (field == null || field.FieldType != typeof(T)) return null;
+#if !NETSTANDARD2_0
+                try // we can try use ref-emit
+                {
+                    var dm = new DynamicMethod(fieldName, typeof(T), new[] { typeof(MulticastDelegate) }, typeof(MulticastDelegate), true);
+                    var il = dm.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, field);
+                    il.Emit(OpCodes.Ret);
+                    return (Func<MulticastDelegate, T>)dm.CreateDelegate(typeof(Func<MulticastDelegate, T>));
+                }
+                catch { }
+#endif
+                return GetViaReflection<T>(field);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+        static Func<MulticastDelegate, T> GetViaReflection<T>(FieldInfo field)
+            => handler => (T)field.GetValue(handler);
+
+        /// <summary>
+        /// Allows allocation-free enumerator over the individual elements of a multicast delegate
+        /// </summary>
+        public readonly struct DelegateEnumerable<T> : IEnumerable<T> where T : MulticastDelegate
+        {
+            private readonly T _handler;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal DelegateEnumerable(T handler) => _handler = handler;
+
+            /// <summary>
+            /// Iterate over the individual elements of a multicast delegate (without allocation)
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public DelegateEnumerator<T> GetEnumerator()
+                => _handler == null ? default : new DelegateEnumerator<T>(_handler);
+            IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        /// <summary>
+        /// Allows allocation-free enumerator over the individual elements of a multicast delegate
+        /// </summary>
+        public struct DelegateEnumerator<T> : IEnumerator<T> where T : MulticastDelegate
+        {
+            private readonly T _handler;
+            private readonly object[] _arr;
+            private readonly int _count;
+            private int _index;
+            private T _current;
+            internal DelegateEnumerator(T handler)
+            {
+                Debug.Assert(handler != null);
+                _handler = handler;
+                if (_isOptimized)
+                {
+                    _arr = (object[])_getArr(handler);
+                    if (_arr == null)
+                    {
+                        _count = 1;
+                    }
+                    else
+                    {
+                        _count = (int)_getCount(handler);
+                    }
+                }
+                else
+                {
+                    _arr = handler.GetInvocationList();
+                    _count = _arr.Length;
+                }
+                _current = null;
+                _index = -1;
+            }
+
+            /// <summary>
+            /// Provides the current value of the seqyence
+            /// </summary>
+            public T Current
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => _current;
+            }
+
+            object IEnumerator.Current => Current;
+
+            void IDisposable.Dispose() { }
+
+            /// <summary>
+            /// Move to the next item in the sequence
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext()
+            {
+                var next = _index + 1;
+                if (next >= _count)
+                {
+                    _current = null;
+                    return false;
+                }
+                _current = _arr == null ? _handler : (T)_arr[next];
+                _index = next;
+                return true;
+            }
+
+            /// <summary>
+            /// Reset the enumerator, allowing the sequence to be repeated
+            /// </summary>
+            public void Reset()
+            {
+                _current = null;
+                _index = -1;
+            }
+        }
+    }
+}

--- a/tests/Benchmark/DelegateBenchmarks.cs
+++ b/tests/Benchmark/DelegateBenchmarks.cs
@@ -1,0 +1,71 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using Pipelines.Sockets.Unofficial;
+using BenchmarkDotNet.Configs;
+
+namespace Benchmark
+{
+    [MemoryDiagnoser, CoreJob, ClrJob, MinColumn, MaxColumn]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    public class DelegateBenchmarks : BenchmarkBase
+    {
+        private const int PER_TEST = 5 * 1024;
+
+        static readonly Func<int> _nil = null, _single = () => 1, _dual = _single + _single;
+
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetInvocationList))]
+        public void GetInvocationList_Nil() => GetInvocationList(_nil).AssertIs(0);
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetInvocationList))]
+        public void GetInvocationList_Single() => GetInvocationList(_single).AssertIs(1);
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetInvocationList))]
+        public void GetInvocationList_Dual() => GetInvocationList(_dual).AssertIs(2);
+
+        private static int GetInvocationList(Func<int> handler)
+        {
+            int count = -1;
+            for (int i = 0; i < PER_TEST; i++)
+            {
+                count = 0;
+                if (handler != null)
+                {
+                    foreach (Func<int> sub in handler.GetInvocationList())
+                    {
+                        count += sub();
+                    }
+                }
+            }
+            return count;
+        }
+
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetEnumerator))]
+        public void GetEnumerator_Nil() => GetEnumerator(_nil).AssertIs(0);
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetEnumerator))]
+        public void GetEnumerator_Single() => GetEnumerator(_single).AssertIs(1);
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetEnumerator))]
+        public void GetEnumerator_Dual() => GetEnumerator(_dual).AssertIs(2);
+
+        private static int GetEnumerator(Func<int> handler)
+        {
+            int count = -1;
+            for (int i = 0; i < PER_TEST; i++)
+            {
+                count = 0;
+                if (handler != null)
+                {
+                    foreach (var sub in handler.AsEnumerable())
+                    {
+                        count += sub();
+                    }
+                }
+            }
+            return count;
+        }
+    }
+}

--- a/tests/Benchmark/DelegateBenchmarks.cs
+++ b/tests/Benchmark/DelegateBenchmarks.cs
@@ -67,5 +67,37 @@ namespace Benchmark
             }
             return count;
         }
+
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetEnumerator_CheckSingle))]
+        public void GetEnumerator_CheckSingle_Nil() => GetEnumerator_CheckSingle(_nil).AssertIs(0);
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetEnumerator_CheckSingle))]
+        public void GetEnumerator_CheckSingle_Single() => GetEnumerator_CheckSingle(_single).AssertIs(1);
+        [Benchmark(OperationsPerInvoke = PER_TEST)]
+        [BenchmarkCategory(nameof(GetEnumerator_CheckSingle))]
+        public void GetEnumerator_CheckSingle_Dual() => GetEnumerator_CheckSingle(_dual).AssertIs(2);
+
+        private static int GetEnumerator_CheckSingle(Func<int> handler)
+        {
+            int count = -1;
+            for (int i = 0; i < PER_TEST; i++)
+            {
+                count = 0;
+                if (handler == null) {}
+                else if (handler.IsSingle())
+                {
+                    count = handler();
+                }
+                else
+                {
+                    foreach (var sub in handler.AsEnumerable())
+                    {
+                        count += sub();
+                    }
+                }
+            }
+            return count;
+        }
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -142,7 +142,18 @@ namespace Pipelines.Sockets.Unofficial.Tests
         [Fact] public Task GetInvocationList_Single() => Run(_ => _.GetInvocationList_Single());
         [Fact] public Task GetInvocationList_Dual() => Run(_ => _.GetInvocationList_Dual());
 
-        [Fact] public void IsOptimized() => Assert.True(Delegates.IsOptimized);
+        [Fact] public Task GetEnumerator_CheckSingle_Nil() => Run(_ => _.GetEnumerator_CheckSingle_Nil());
+        [Fact] public Task GetEnumerator_CheckSingle_Single() => Run(_ => _.GetEnumerator_CheckSingle_Single());
+        [Fact] public Task GetEnumerator_CheckSingle_Dual() => Run(_ => _.GetEnumerator_CheckSingle_Dual());
+
+        [Fact]
+        public void IsAvailable() => Assert.True(Delegates.IsAvailable);
+
+        static readonly Action _single = () => { }, _dual = _single + _single;
+        [Fact]
+        public void Single_Ack() => Assert.True(_single.IsSingle());
+        [Fact]
+        public void Single_Nack() => Assert.False(_dual.IsSingle());
 
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BenchmarkTests.cs
@@ -130,4 +130,19 @@ namespace Pipelines.Sockets.Unofficial.Tests
         [Fact] public Task SemaphoreSlim_ConcurrentLoadAsync() => Run(_ => _.SemaphoreSlim_ConcurrentLoadAsync());
         [Fact] public Task SemaphoreSlim_Sync() => Run(_ => _.SemaphoreSlim_Sync());
     }
+    public class DelegateBenchmarkTests : BenchmarkTests<DelegateBenchmarks>
+    {
+        public DelegateBenchmarkTests(ITestOutputHelper output) : base(output, 10) { }
+
+        [Fact] public Task GetEnumerator_Nil() => Run(_ => _.GetEnumerator_Nil());
+        [Fact] public Task GetEnumerator_Single() => Run(_ => _.GetEnumerator_Single());
+        [Fact] public Task GetEnumerator_Dual() => Run(_ => _.GetEnumerator_Dual());
+
+        [Fact] public Task GetInvocationList_Nil() => Run(_ => _.GetInvocationList_Nil());
+        [Fact] public Task GetInvocationList_Single() => Run(_ => _.GetInvocationList_Single());
+        [Fact] public Task GetInvocationList_Dual() => Run(_ => _.GetInvocationList_Dual());
+
+        [Fact] public void IsOptimized() => Assert.True(Delegates.IsOptimized);
+
+    }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
@@ -27,8 +27,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Benchmark\ArenaBenchmarks.cs" />
-    <Compile Include="..\Benchmark\LockBenchmarks.cs" />
+    <Compile Include="..\Benchmark\*Benchmarks.cs" />
     <Compile Include="..\Benchmark\Utils.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add APIs to allow working with multi-cast delegates without allocating

| Method | Job | Runtime | Categories | Mean | Error | StdDev | Min | Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------------------- |----- |-------- |-------------------------- |-----------:|----------:|----------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|            GetInvocationList_Nil |  Clr |     Clr |         GetInvocationList |  0.6508 ns | 0.0053 ns | 0.0049 ns |  0.6409 ns |  0.6555 ns |           - |           - |           - |                   - |
|         GetInvocationList_Single |  Clr |     Clr |         GetInvocationList | 15.7775 ns | 0.0704 ns | 0.0624 ns | 15.6760 ns | 15.8719 ns |      0.0051 |           - |           - |                32 B |
|           GetInvocationList_Dual |  Clr |     Clr |         GetInvocationList | 32.5536 ns | 0.0458 ns | 0.0406 ns | 32.4848 ns | 32.6278 ns |      0.0063 |           - |           - |                40 B |
|            GetInvocationList_Nil | Core |    Core |         GetInvocationList |  0.6441 ns | 0.0018 ns | 0.0017 ns |  0.6420 ns |  0.6472 ns |           - |           - |           - |                   - |
|         GetInvocationList_Single | Core |    Core |         GetInvocationList | 14.7447 ns | 0.1567 ns | 0.1466 ns | 14.5181 ns | 15.0292 ns |      0.0051 |           - |           - |                32 B |
|           GetInvocationList_Dual | Core |    Core |         GetInvocationList | 27.7171 ns | 0.1433 ns | 0.1119 ns | 27.5760 ns | 27.9416 ns |      0.0063 |           - |           - |                40 B |
|                                  |      |         |                           |            |           |           |            |            |             |             |             |                     |
|                GetEnumerator_Nil |  Clr |     Clr |             GetEnumerator |  0.4304 ns | 0.0008 ns | 0.0007 ns |  0.4296 ns |  0.4319 ns |           - |           - |           - |                   - |
|             GetEnumerator_Single |  Clr |     Clr |             GetEnumerator | 13.4696 ns | 0.0134 ns | 0.0119 ns | 13.4496 ns | 13.4931 ns |           - |           - |           - |                   - |
|               GetEnumerator_Dual |  Clr |     Clr |             GetEnumerator | 22.8341 ns | 0.0772 ns | 0.0723 ns | 22.7423 ns | 22.9586 ns |           - |           - |           - |                   - |
|                GetEnumerator_Nil | Core |    Core |             GetEnumerator |  0.4304 ns | 0.0005 ns | 0.0004 ns |  0.4298 ns |  0.4309 ns |           - |           - |           - |                   - |
|             GetEnumerator_Single | Core |    Core |             GetEnumerator | 14.6639 ns | 0.0376 ns | 0.0294 ns | 14.6313 ns | 14.7344 ns |           - |           - |           - |                   - |
|               GetEnumerator_Dual | Core |    Core |             GetEnumerator | 22.7162 ns | 0.0396 ns | 0.0370 ns | 22.6649 ns | 22.7845 ns |           - |           - |           - |                   - |
|                                  |      |         |                           |            |           |           |            |            |             |             |             |                     |
|    GetEnumerator_CheckSingle_Nil |  Clr |     Clr | GetEnumerator_CheckSingle |  0.6442 ns | 0.0019 ns | 0.0017 ns |  0.6420 ns |  0.6475 ns |           - |           - |           - |                   - |
| GetEnumerator_CheckSingle_Single |  Clr |     Clr | GetEnumerator_CheckSingle |  5.3620 ns | 0.0229 ns | 0.0203 ns |  5.3379 ns |  5.4101 ns |           - |           - |           - |                   - |
|   GetEnumerator_CheckSingle_Dual |  Clr |     Clr | GetEnumerator_CheckSingle | 27.2090 ns | 0.0453 ns | 0.0401 ns | 27.1650 ns | 27.2917 ns |           - |           - |           - |                   - |
|    GetEnumerator_CheckSingle_Nil | Core |    Core | GetEnumerator_CheckSingle |  0.4482 ns | 0.0049 ns | 0.0046 ns |  0.4364 ns |  0.4520 ns |           - |           - |           - |                   - |
| GetEnumerator_CheckSingle_Single | Core |    Core | GetEnumerator_CheckSingle |  5.2312 ns | 0.0118 ns | 0.0104 ns |  5.2126 ns |  5.2478 ns |           - |           - |           - |                   - |
|   GetEnumerator_CheckSingle_Dual | Core |    Core | GetEnumerator_CheckSingle | 27.4683 ns | 0.4160 ns | 0.3688 ns | 26.4948 ns | 27.8895 ns |           - |           - |           - |                   - |
