### PR TITLE
Array pool memory stream

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/ArrayPoolStream.cs
+++ b/src/Pipelines.Sockets.Unofficial/ArrayPoolStream.cs
@@ -1,0 +1,283 @@
+﻿using Pipelines.Sockets.Unofficial.Internal;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+#nullable enable
+namespace Pipelines.Sockets.Unofficial
+{
+    /// <summary>
+    /// ArrayPoolStream is a lot like MemoryStream, except it rents contiguous buffers from the array pool
+    /// </summary>
+    public sealed class ArrayPoolStream : Stream
+    {
+        /// <inheritdoc/>
+        public override string ToString() => $"{nameof(ArrayPoolStream)} at position {Position} of {Length}";
+
+        private readonly ArrayPool<byte> _pool;
+        private byte[] _array = Array.Empty<byte>();
+        private int _position, _length;
+
+        /// <summary>Create a new ArrayPoolStream using the default array pool</summary>
+        public ArrayPoolStream() => _pool = ArrayPool<byte>.Shared;
+
+        /// <summary>Create a new ArrayPoolStream using the specified array pool</summary>
+        public ArrayPoolStream(ArrayPool<byte> pool) => _pool = pool ?? ArrayPool<byte>.Shared;
+
+        /// <inheritdoc/>
+        public override bool CanRead => true;
+        /// <inheritdoc/>
+        public override bool CanWrite => true;
+        /// <inheritdoc/>
+        public override bool CanTimeout => false;
+        /// <inheritdoc/>
+        public override bool CanSeek => true;
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get => _position;
+            set
+            {
+                if (_position < 0 || _position > _length) Throw.ArgumentOutOfRange(nameof(Position));
+                _position = (int)value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override long Length => _length;
+
+        /// <inheritdoc/>
+        public override void SetLength(long value)
+        {
+            if (value < 0 || value > int.MaxValue) Throw.ArgumentOutOfRange(nameof(value));
+            if (value == _length)
+            { } // nothing to do
+            else if (value < _length) // shrink
+            {
+                _length = (int)value;
+                if (_position > _length) _position = _length; // leave at EOF
+            }
+            else // grow
+            {
+                var oldLen = _length;
+                ExpandCapacity((int)value);
+                new Span<byte>(_array, oldLen, _length).Clear(); // zero the contents when growing this way
+            }
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch(origin)
+            {
+                case SeekOrigin.Begin:
+                    return Position = offset;
+                case SeekOrigin.End:
+                    return Position = Length + offset;
+                case SeekOrigin.Current:
+                    return Position += offset;
+                default:
+                    Throw.ArgumentOutOfRange(nameof(origin));
+                    return default;
+            }
+        }
+
+        /// <summary>
+        /// Exposes the underlying buffer associated with this stream, for the defined length
+        /// </summary>
+        public bool TryGetBuffer(out ArraySegment<byte> buffer)
+        {
+            buffer = new ArraySegment<byte>(_array, 0, _length);
+            return _length >= 0;
+        }
+
+        /// <inheritdoc/>
+        public override void Flush() { }
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _position = _length = -1;
+                var arr = _array;
+                _array = Array.Empty<byte>();
+
+                if (arr.Length != 0) _pool.Return(arr);
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int take = Math.Min(count, _length - _position);
+            Buffer.BlockCopy(_array, _position, buffer, offset, take);
+            _position += take;
+            return take;
+        }
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var positionAfter = _position + count;
+            if (positionAfter < 0) Throw.InvalidOperation();
+            if (positionAfter > _length) ExpandCapacity(positionAfter);
+            Buffer.BlockCopy(buffer, offset, _array, _position, count);
+            _position = positionAfter;
+        }
+
+        /// <inheritdoc/>
+        public override int ReadByte()
+            => _position >= _length ? -1 : _array[_position++];
+
+        /// <inheritdoc/>
+        public override void WriteByte(byte value)
+        {
+            if (_position >= _length) ExpandCapacity(_length + 1);
+            _array[_position++] = value;
+        }
+
+        private static readonly Task<int> s_Zero = Task.FromResult<int>(0);
+
+        private Task<int>? _lastSuccessfulReadTask; // buffer successful large reads, since they tend to be repetitive and same-sized (buffers, etc)
+        /// <inheritdoc/>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested) return Task.FromCanceled<int>(cancellationToken);
+            try
+            {
+                int bytes = Read(buffer, offset, count);
+                if (bytes == 0) return s_Zero;
+
+                if (_lastSuccessfulReadTask != null && _lastSuccessfulReadTask.Result == bytes) return _lastSuccessfulReadTask;
+                return _lastSuccessfulReadTask = Task.FromResult(bytes);
+            }
+            catch(Exception ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested) return Task.FromCanceled<int>(cancellationToken);
+            try
+            {
+                Write(buffer, offset, count);
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ExpandCapacity(int capacity)
+        {
+            if (capacity > _array.Length) TakeNewBuffer(capacity);
+            _length = capacity;
+        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TakeNewBuffer(int capacity)
+        {
+            var oldArr = _array;
+            var newArr = _pool.Rent(capacity);
+            if (_length != 0) Buffer.BlockCopy(oldArr, 0, newArr, 0, _length);
+            _array = newArr;
+            if (oldArr.Length != 0) _pool.Return(oldArr);
+        }
+
+        /// <inheritdoc/>
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested) return Task.FromCanceled(cancellationToken);
+
+            if (destination is MemoryStream || destination is ArrayPoolStream)
+            {
+                // write sync
+                try
+                {
+                    destination.Write(_array, _position, _length - _position);
+                    _position = _length;
+                    return Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException(ex);
+                }
+            }
+            else
+            {
+                var task = destination.WriteAsync(_array, _position, _length - _position);
+                _position = _length;
+                return task;
+            }
+        }
+
+#if SOCKET_STREAM_BUFFERS
+        /// <inheritdoc/>
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            destination.Write(_array, _position, _length - _position);
+            _position = _length;
+        }
+
+        /// <inheritdoc/>
+        public override int Read(Span<byte> buffer)
+        {
+            int take = Math.Min(buffer.Length, _length - _position);
+            new Span<byte>(_array, _position, take).CopyTo(buffer);
+            _position += take;
+            return take;
+        }
+
+        /// <inheritdoc/>
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            var positionAfter = _position + buffer.Length;
+            if (positionAfter < 0) Throw.InvalidOperation();
+            if (positionAfter > _length) ExpandCapacity(positionAfter);
+            buffer.CopyTo(new Span<byte>(_array, _position, buffer.Length));
+            _position = positionAfter;
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested) return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
+
+            try
+            {
+                return new ValueTask<int>(Read(buffer.Span));
+            }
+            catch(Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested) return new ValueTask(Task.FromCanceled(cancellationToken));
+
+            try
+            {
+                Write(buffer.Span);
+                return default;
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask(Task.FromException<int>(ex));
+            }
+        }
+#endif
+    }
+}

--- a/src/Pipelines.Sockets.Unofficial/Pipelines.Sockets.Unofficial.csproj
+++ b/src/Pipelines.Sockets.Unofficial/Pipelines.Sockets.Unofficial.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- note: net46 causes binding redirect problems on System.Buffers; see conversation https://github.com/mgravell/Pipelines.Sockets.Unofficial/pull/4 -->
-    <TargetFrameworks>net461;net472;netstandard2.0;netcoreapp2.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;net472;netstandard2.0;netcoreapp2.1;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -25,6 +25,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
     <DefineConstants>$(DefineConstants);SOCKET_STREAM_BUFFERS;RANGES</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
+    <DefineConstants>$(DefineConstants);SOCKET_STREAM_BUFFERS;RANGES;LZCNT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />

--- a/tests/Benchmark/ArrayPoolStreamBenchmark.cs
+++ b/tests/Benchmark/ArrayPoolStreamBenchmark.cs
@@ -15,7 +15,7 @@ namespace Benchmark
         private readonly byte[] Chunk = new byte[2048];
         public ArrayPoolStreamBenchmark() => new Random(12345).NextBytes(Chunk);
 
-        [Params(0, 100, 1_000, 10_000, 100_000, 1_000_000, 5_000_000)]
+        [Params(0, 100, 1_000, 10_000, 100_000, 1_000_000, 5_000_000, 10_000_000, 50_000_000)]
         public int Bytes { get; set; }
 
         [Benchmark(Baseline = true)]

--- a/tests/Benchmark/ArrayPoolStreamBenchmark.cs
+++ b/tests/Benchmark/ArrayPoolStreamBenchmark.cs
@@ -1,0 +1,41 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Pipelines.Sockets.Unofficial;
+using System;
+using System.IO;
+
+namespace Benchmark
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net472)]
+    [WarmupCount(2)]
+    public class ArrayPoolStreamBenchmark
+    {
+        private readonly byte[] Chunk = new byte[2048];
+        public ArrayPoolStreamBenchmark() => new Random(12345).NextBytes(Chunk);
+
+        [Params(0, 100, 1_000, 10_000, 100_000, 1_000_000, 5_000_000)]
+        public int Bytes { get; set; }
+
+        [Benchmark(Baseline = true)]
+        public long MemoryStream() => Write<MemoryStream>();
+
+        [Benchmark]
+        public long ArrayPoolStream() => Write<ArrayPoolStream>();
+
+        private long Write<T>() where T : Stream, new()
+        {
+            using var stream = new T();
+            int remaining = Bytes;
+            while (remaining > 0)
+            {
+                int take = Math.Min(remaining, Chunk.Length);
+                stream.Write(Chunk, 0, take);
+                remaining -= take;
+            }
+            if (Bytes != stream.Length) throw new InvalidOperationException("Length mismatch!");
+            return stream.Length;
+        }
+    }
+}

--- a/tests/Pipelines.Sockets.Unofficial.Tests/ArrayPoolStreamTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/ArrayPoolStreamTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pipelines.Sockets.Unofficial.Tests
+{
+    public class ArrayPoolStreamTests
+    {
+        public ArrayPoolStreamTests(ITestOutputHelper output)
+            => _output = output;
+        private readonly ITestOutputHelper _output;
+        private void Log(string message) => _output?.WriteLine(message);
+
+        [Fact]
+        public void TestArrayPoolViaGZipStream()
+        {
+            byte[] arr = new byte[1024];
+            const int loop = 100;
+            new Random(12345).NextBytes(arr);
+            using (var buffer = new ArrayPoolStream())
+            {
+                using (var zip = new GZipStream(buffer, CompressionLevel.Optimal, true))
+                {
+                    for (int i = 0; i < loop; i++)
+                    {
+                        zip.Write(arr, 0, arr.Length);
+                    }
+                    zip.Flush();
+                }
+                Log($"written: {loop * arr.Length} bytes, gzip: {buffer.Length} bytes");
+                buffer.Position = 0;
+                using (var zip = new GZipStream(buffer, CompressionMode.Decompress))
+                {
+                    var ms = new MemoryStream();
+                    zip.CopyTo(ms);
+                    Assert.True(ms.TryGetBuffer(out var segment));
+                    Assert.Equal(loop * arr.Length, segment.Count);
+                    for (int i = 0; i < loop; i++)
+                    {
+                        Assert.True(new Span<byte>(segment.Array, segment.Offset + (i * arr.Length), arr.Length).SequenceEqual(arr));
+                    }
+                    Log($"validated: {loop}x{arr.Length} bytes");
+                }
+            }
+        }
+    }
+}

--- a/tests/Pipelines.Sockets.Unofficial.Tests/ArrayPoolStreamTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/ArrayPoolStreamTests.cs
@@ -45,5 +45,31 @@ namespace Pipelines.Sockets.Unofficial.Tests
                 }
             }
         }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(-1, -1)]
+        [InlineData(int.MinValue, int.MinValue)]
+        [InlineData(1, 1)]
+        [InlineData(2, 2)]
+        [InlineData(3, 4)]
+        [InlineData(4, 4)]
+        [InlineData(5, 8)]
+        [InlineData(6, 8)]
+        [InlineData(7, 8)]
+        [InlineData(8, 8)]
+        [InlineData(9, 16)]
+        [InlineData(913, 1024)]
+        [InlineData(1023, 1024)]
+        [InlineData(1024, 1024)]
+        [InlineData(1025, 2048)]
+        [InlineData(0b0010_0000_0000_0000_0000_0000_0000_0001, 0b0100_0000_0000_0000_0000_0000_0000_0000)]
+        [InlineData(0b0100_0000_0000_0000_0000_0000_0000_0000, 0b0100_0000_0000_0000_0000_0000_0000_0000)]
+        [InlineData(0b0100_0000_0000_0000_0000_0000_0000_0001, 0b0111_1111_1111_1111_1111_1111_1111_1111)]
+        [InlineData(0b0111_1111_1111_1111_1111_1111_1111_1111, 0b0111_1111_1111_1111_1111_1111_1111_1111)]
+        public void ValidateRoundUpBehavior(int capacity, int expected)
+        {
+            Assert.Equal(expected, ArrayPoolStream.RoundUp(capacity));
+        }
     }
 }

--- a/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/Pipelines.Sockets.Unofficial.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon />
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Provides something similar to `MemoryStream`, but which loans memory from the array-pool; for sizes up to the pool's upper limit, this improves allocations and performance; for sizes over the pool's upper limit, it tracks `MemoryStream` for perf etc

|          Method |       Runtime |    Bytes |             Mean |          Error |         StdDev |           Median | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 |   Allocated |
|---------------- |-------------- |--------- |-----------------:|---------------:|---------------:|-----------------:|------:|--------:|----------:|----------:|----------:|------------:|
|    MemoryStream |    .NET 4.7.2 |        0 |      1,364.23 ns |      45.405 ns |      52.289 ns |      1,346.64 ns |  1.00 |    0.00 |    0.1926 |         - |         - |      1220 B |
| ArrayPoolStream |    .NET 4.7.2 |        0 |      1,614.82 ns |      13.611 ns |      12.066 ns |      1,615.72 ns |  1.18 |    0.05 |    0.2747 |         - |         - |      1733 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |        0 |         39.54 ns |       0.515 ns |       0.481 ns |         39.43 ns |  1.00 |    0.00 |    0.0086 |         - |         - |        72 B |
| ArrayPoolStream | .NET Core 3.1 |        0 |         39.91 ns |       0.507 ns |       0.474 ns |         39.93 ns |  1.01 |    0.02 |    0.0076 |         - |         - |        64 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 |      100 |      1,386.19 ns |      15.762 ns |      14.744 ns |      1,386.67 ns |  1.00 |    0.00 |    0.2365 |         - |         - |      1500 B |
| ArrayPoolStream |    .NET 4.7.2 |      100 |      1,676.58 ns |       9.549 ns |       7.974 ns |      1,678.43 ns |  1.21 |    0.02 |    0.2747 |         - |         - |      1733 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |      100 |         71.54 ns |       0.752 ns |       0.703 ns |         71.60 ns |  1.00 |    0.00 |    0.0421 |         - |         - |       352 B |
| ArrayPoolStream | .NET Core 3.1 |      100 |         82.56 ns |       0.901 ns |       0.843 ns |         82.53 ns |  1.15 |    0.02 |    0.0076 |         - |         - |        64 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 |     1000 |      1,466.98 ns |      21.271 ns |      19.897 ns |      1,468.47 ns |  1.00 |    0.00 |    0.3548 |         - |         - |      2247 B |
| ArrayPoolStream |    .NET 4.7.2 |     1000 |      1,792.64 ns |      34.731 ns |      39.997 ns |      1,787.87 ns |  1.23 |    0.04 |    0.2747 |         - |         - |      1733 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |     1000 |        115.68 ns |       1.286 ns |       1.140 ns |        115.27 ns |  1.00 |    0.00 |    0.1310 |    0.0005 |         - |      1096 B |
| ArrayPoolStream | .NET Core 3.1 |     1000 |         94.71 ns |       1.528 ns |       1.430 ns |         94.73 ns |  0.82 |    0.01 |    0.0076 |         - |         - |        64 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 |    10000 |      3,385.81 ns |      26.918 ns |      25.179 ns |      3,385.13 ns |  1.00 |    0.00 |    5.1003 |    0.3891 |         - |     32114 B |
| ArrayPoolStream |    .NET 4.7.2 |    10000 |      2,396.58 ns |      17.707 ns |      16.563 ns |      2,403.06 ns |  0.71 |    0.01 |    0.2708 |         - |         - |      1733 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |    10000 |      1,921.56 ns |      35.086 ns |      31.103 ns |      1,919.78 ns |  1.00 |    0.00 |    3.6888 |    0.2136 |         - |     30889 B |
| ArrayPoolStream | .NET Core 3.1 |    10000 |        558.52 ns |      11.145 ns |      26.702 ns |        543.93 ns |  0.31 |    0.01 |    0.0076 |         - |         - |        64 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 |   100000 |     48,543.91 ns |     479.858 ns |     448.859 ns |     48,461.05 ns |  1.00 |    0.00 |   41.6260 |   41.6260 |   41.6260 |    261678 B |
| ArrayPoolStream |    .NET 4.7.2 |   100000 |      7,116.44 ns |      84.081 ns |      78.650 ns |      7,098.91 ns |  0.15 |    0.00 |    0.2670 |         - |         - |      1733 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |   100000 |     46,856.50 ns |     283.722 ns |     251.512 ns |     46,798.32 ns |  1.00 |    0.00 |   41.6260 |   41.6260 |   41.6260 |    260351 B |
| ArrayPoolStream | .NET Core 3.1 |   100000 |      4,469.42 ns |      39.937 ns |      37.357 ns |      4,472.42 ns |  0.10 |    0.00 |    0.0076 |         - |         - |        64 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 |  1000000 |    663,115.10 ns |   5,952.064 ns |   5,567.564 ns |    663,140.04 ns |  1.00 |    0.00 |  499.0234 |  499.0234 |  499.0234 |   2097440 B |
| ArrayPoolStream |    .NET 4.7.2 |  1000000 |     59,805.30 ns |     876.384 ns |     819.771 ns |     60,177.60 ns |  0.09 |    0.00 |    0.1221 |         - |         - |      1734 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |  1000000 |    663,987.63 ns |   2,786.481 ns |   2,470.143 ns |    664,602.44 ns |  1.00 |    0.00 |  499.0234 |  499.0234 |  499.0234 |   2095596 B |
| ArrayPoolStream | .NET Core 3.1 |  1000000 |     59,923.22 ns |   1,113.846 ns |   1,093.946 ns |     59,853.89 ns |  0.09 |    0.00 |         - |         - |         - |        64 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 |  5000000 |  5,005,030.59 ns |  26,680.251 ns |  22,279.218 ns |  5,001,619.53 ns |  1.00 |    0.00 |  742.1875 |  742.1875 |  742.1875 |  16777576 B |
| ArrayPoolStream |    .NET 4.7.2 |  5000000 |  4,478,622.81 ns |  26,326.782 ns |  24,626.088 ns |  4,476,832.03 ns |  0.89 |    0.01 |  406.2500 |  406.2500 |  406.2500 |  14682914 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 |  5000000 |  5,003,977.73 ns |  37,501.681 ns |  33,244.263 ns |  4,998,119.53 ns |  1.00 |    0.00 |  742.1875 |  742.1875 |  742.1875 |  16775638 B |
| ArrayPoolStream | .NET Core 3.1 |  5000000 |  4,410,789.73 ns |  19,553.125 ns |  17,333.336 ns |  4,411,112.50 ns |  0.88 |    0.01 |  406.2500 |  406.2500 |  406.2500 |  14680270 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 | 10000000 | 10,164,154.69 ns |  61,059.369 ns |  54,127.540 ns | 10,156,482.03 ns |  1.00 |    0.00 | 1484.3750 | 1484.3750 | 1484.3750 |  33554816 B |
| ArrayPoolStream |    .NET 4.7.2 | 10000000 | 10,383,601.98 ns | 179,466.463 ns | 167,873.041 ns | 10,388,040.63 ns |  1.02 |    0.02 |  640.6250 |  640.6250 |  640.6250 |  31460792 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 | 10000000 | 10,100,732.92 ns |  66,038.903 ns |  61,772.831 ns | 10,096,959.38 ns |  1.00 |    0.00 | 1484.3750 | 1484.3750 | 1484.3750 |  33552960 B |
| ArrayPoolStream | .NET Core 3.1 | 10000000 | 12,560,870.54 ns |  71,945.603 ns |  63,777.903 ns | 12,555,185.16 ns |  1.24 |    0.01 |  640.6250 |  640.6250 |  640.6250 |  31457553 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream |    .NET 4.7.2 | 50000000 | 47,874,466.06 ns | 263,497.917 ns | 246,476.115 ns | 47,872,445.45 ns |  1.00 |    0.00 | 3909.0909 | 3909.0909 | 3909.0909 | 134218160 B |
| ArrayPoolStream |    .NET 4.7.2 | 50000000 | 46,582,338.79 ns | 218,688.724 ns | 204,561.569 ns | 46,587,054.55 ns |  0.97 |    0.01 | 1909.0909 | 1909.0909 | 1909.0909 | 132127261 B |
|                 |               |          |                  |                |                |                  |       |         |           |           |           |             |
|    MemoryStream | .NET Core 3.1 | 50000000 | 47,060,175.97 ns | 164,637.017 ns | 145,946.427 ns | 47,055,445.45 ns |  1.00 |    0.00 | 3909.0909 | 3909.0909 | 3909.0909 | 134216425 B |
| ArrayPoolStream | .NET Core 3.1 | 50000000 | 46,196,160.39 ns | 346,976.745 ns | 307,585.847 ns | 46,140,322.73 ns |  0.98 |    0.01 | 1909.0909 | 1909.0909 | 1909.0909 | 132121074 B |