### PR TITLE
Benchmarcs: update to net6.0 and stuff

### DIFF
--- a/Benchmarks.cmd
+++ b/Benchmarks.cmd
@@ -1,2 +1,2 @@
 @ECHO OFF
-dotnet run -p .\tests\Benchmark\ -c Release -f netcoreapp2.2 --runtimes net472 netcoreapp2.2 -m
+dotnet run --project .\tests\Benchmark\ -c Release -f net6.0 --runtimes net472 net6.0 -m %*

--- a/tests/Benchmark/ArrayPoolStreamBenchmark.cs
+++ b/tests/Benchmark/ArrayPoolStreamBenchmark.cs
@@ -8,8 +8,6 @@ using System.IO;
 namespace Benchmark
 {
     [MemoryDiagnoser]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
-    [SimpleJob(RuntimeMoniker.Net472)]
     [WarmupCount(2)]
     public class ArrayPoolStreamBenchmark
     {

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/tests/Benchmark/DelegateBenchmarks.cs
+++ b/tests/Benchmark/DelegateBenchmarks.cs
@@ -6,8 +6,6 @@ using BenchmarkDotNet.Jobs;
 
 namespace Benchmark
 {
-    [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [MemoryDiagnoser, MinColumn, MaxColumn]
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]

--- a/tests/Benchmark/LockBenchmarks.cs
+++ b/tests/Benchmark/LockBenchmarks.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 
 namespace Benchmark
 {
-    [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [MemoryDiagnoser, MinColumn, MaxColumn]
     public class LockBenchmarks : BenchmarkBase
     {

--- a/tests/Benchmark/Program.cs
+++ b/tests/Benchmark/Program.cs
@@ -9,9 +9,7 @@ namespace Benchmark
         {
             if (args == null || args.Length == 0)
             {   // if no args, we're probably using Ctrl+F5 in the IDE; enlargen thyself!
-#pragma warning disable CA1416 // windows only
                 try { Console.WindowWidth = Console.LargestWindowWidth - 20; } catch { }
-#pragma warning restore CA1416 // windows only
             }
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }


### PR DESCRIPTION
Done for #64, runs can now invoked via:
```ps
.\Benchmarks.cmd --filter *Lock*
```