### PR TITLE
Fix NativeAOT warnings

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/Arenas/PerTypeHelpers.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/PerTypeHelpers.cs
@@ -12,7 +12,11 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
             static Allocator<T> Calculate()
             {
-                if (IsBlittable)
+                if (IsBlittable
+#if NETCOREAPP3_0_OR_GREATER
+                    && RuntimeFeature.IsDynamicCodeSupported
+#endif
+                )
                 {
                     try
                     {
@@ -32,7 +36,11 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
             static Allocator<T> Calculate()
             {
-                if (IsBlittable)
+                if (IsBlittable
+#if NETCOREAPP3_0_OR_GREATER
+                    && RuntimeFeature.IsDynamicCodeSupported
+#endif
+                )
                 {
                     try
                     {


### PR DESCRIPTION
- Check IsDynamicCodeSupported in Delegates.GetGetter before trying to create a DynamicMethod
- Check IsDynamicCodeSupported in PerTypeHelpers before trying to MakeGenericType, which can fail for value types in NativeAOT.

Fix #72

cc @mgravell 