### PR TITLE
Memory Leak: BufferWriter Array Return Failure

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/Buffers/BufferWriter.cs
+++ b/src/Pipelines.Sockets.Unofficial/Buffers/BufferWriter.cs
@@ -383,9 +383,9 @@ namespace Pipelines.Sockets.Unofficial.Buffers
                 if (Volatile.Read(ref _count) > 0 && Interlocked.Decrement(ref _count) == 0)
                 {
                     DecrLiveCount();
-                    Memory = default;
                     DetachNext(); // break the chain, in case of dangling references
                     ReleaseImpl();
+                    Memory = default;
                 }
             }
 

--- a/tests/Pipelines.Sockets.Unofficial.Tests/BufferWriterTests.cs
+++ b/tests/Pipelines.Sockets.Unofficial.Tests/BufferWriterTests.cs
@@ -106,6 +106,28 @@ namespace Pipelines.Sockets.Unofficial.Tests
 
         }
 
+        [Fact]
+        public void BufferWriterReturnsMemoryToPool()
+        {
+#pragma warning disable IDE0063 // this would break the "all dead now" test
+            using (var bw = BufferWriter<byte>.Create(blockSize: 1 << 8))
+#pragma warning restore IDE0063
+            {
+                var span = bw.GetSpan(1);
+                span[0] = 123;
+                span[128] = 210;
+                bw.Advance((1 << 8));
+                bw.Flush().Dispose();
+
+                // Release the head off the buffer.
+                bw.GetSpan(1);
+
+                var rent = ArrayPool<byte>.Shared.Rent(1 << 8);
+                Assert.Equal(123, rent[0]);
+                Assert.Equal(210, rent[128]);
+            }
+        }
+
         static string GetState(ReadOnlySequence<byte> ros)
         {
             var start = ros.Start;


### PR DESCRIPTION
Found a bug where the `SequenceSegment<T>.Memory` was being set to `default` prior to the `RefCountedSegment.ReleaseImpl()` method invocation.  This has the effect of the implementation attempting to return default `Memory<byte>.Empty` array which is discarded by the pool.  The GC obviously picks this up in the end, but it prevents the pool from reusing the memory.

The fix for this is changing the order of the setting of the memory to default and the `ReleaseImpl` invocation.

Added a test for this fix.  I encountered one failure of `BufferWriterTests.BufferWriterDoesNotLeak()` but I could not reproduce the onetime failure.  Unless I'm missing something, I don't see how this modification would cause the test failure.
