### PR TITLE
Docs: fix DedicatedThreadPoolPipeScheduler.AvailableCount description

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/DedicatedThreadPoolPipeScheduler.cs
+++ b/src/Pipelines.Sockets.Unofficial/DedicatedThreadPoolPipeScheduler.cs
@@ -144,7 +144,7 @@ namespace Pipelines.Sockets.Unofficial
 
         private int _availableCount;
         /// <summary>
-        /// The number of workers currently actively engaged in work
+        /// The number of workers currently available and awaiting work
         /// </summary>
         public int AvailableCount => Thread.VolatileRead(ref _availableCount);
 


### PR DESCRIPTION
This was reported from a user of StackExchange.Redis looking at code for how this works, loops like an inversion between meaning/docs - fixing!