### PR TITLE
Remove AOT deoptimization

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/Arenas/PerTypeHelpers.cs
+++ b/src/Pipelines.Sockets.Unofficial/Arenas/PerTypeHelpers.cs
@@ -100,11 +100,7 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
             static Allocator<T> Calculate()
             {
-                if (IsBlittable
-#if NETCOREAPP3_0_OR_GREATER
-                    && RuntimeFeature.IsDynamicCodeSupported
-#endif
-                )
+                if (IsBlittable)
                 {
                     return UnmanagedAllocator<T>.Shared;
                 }
@@ -118,11 +114,7 @@ namespace Pipelines.Sockets.Unofficial.Arenas
 
             static Allocator<T> Calculate()
             {
-                if (IsBlittable
-#if NETCOREAPP3_0_OR_GREATER
-                    && RuntimeFeature.IsDynamicCodeSupported
-#endif
-                )
+                if (IsBlittable)
                 {
                     return PinnedArrayPoolAllocator<T>.Shared;
                 }


### PR DESCRIPTION
I looked at this because of https://github.com/mgravell/Pipelines.Sockets.Unofficial/pull/73#discussion_r1180567340.

Digging in code history, I saw that the reflection was there because previously this was `T: unmanaged` and we'd need "bridging constraints" feature to avoid reflection here: https://github.com/dotnet/csharplang/discussions/6308.

But I see that the `where T : unmanaged` is no longer there and neither is the reflection. Can we not just take this code path?

Cc @eerhardt 