### PR TITLE
Typo fix in PipeShutdownKind. Replace Thread.VolatileRead with Volatile.Read

### DIFF
--- a/src/Pipelines.Sockets.Unofficial/DedicatedThreadPoolPipeScheduler.cs
+++ b/src/Pipelines.Sockets.Unofficial/DedicatedThreadPoolPipeScheduler.cs
@@ -146,7 +146,7 @@ namespace Pipelines.Sockets.Unofficial
         /// <summary>
         /// The number of workers currently available and awaiting work
         /// </summary>
-        public int AvailableCount => Thread.VolatileRead(ref _availableCount);
+        public int AvailableCount => Volatile.Read(ref _availableCount);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Execute(Action<object> action, object state)

--- a/src/Pipelines.Sockets.Unofficial/Helpers.cs
+++ b/src/Pipelines.Sockets.Unofficial/Helpers.cs
@@ -91,7 +91,7 @@ namespace Pipelines.Sockets.Unofficial
             var sb = new System.Text.StringBuilder();
             for(int i = 0 ; i < enums.Length ; i++)
             {
-                var count = Thread.VolatileRead(ref _counters[(int)enums[i]]);
+                var count = Volatile.Read(ref _counters[(int)enums[i]]);
                 if (count != 0) sb.Append(enums[i]).Append(":\t").Append(count).AppendLine();
             }
             lock(_execCount)

--- a/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
+++ b/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
@@ -123,7 +123,7 @@ namespace Pipelines.Sockets.Unofficial
         private int _socketShutdownKind;
         /// <summary>
         /// When possible, determines how the pipe first reached a close state
-        /// </summary>        
+        /// </summary>
         public PipeShutdownKind ShutdownKind => (PipeShutdownKind)Volatile.Read(ref _socketShutdownKind);
         /// <summary>
         /// When the ShutdownKind relates to a socket error, may contain the socket error code

--- a/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
+++ b/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
@@ -123,8 +123,8 @@ namespace Pipelines.Sockets.Unofficial
         private int _socketShutdownKind;
         /// <summary>
         /// When possible, determines how the pipe first reached a close state
-        /// </summary>
-        public PipeShutdownKind ShutdownKind => (PipeShutdownKind)Thread.VolatileRead(ref _socketShutdownKind);
+        /// </summary>        
+        public PipeShutdownKind ShutdownKind => (PipeShutdownKind)Volatile.Read(ref _socketShutdownKind);
         /// <summary>
         /// When the ShutdownKind relates to a socket error, may contain the socket error code
         /// </summary>

--- a/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
+++ b/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
@@ -59,7 +59,7 @@ namespace Pipelines.Sockets.Unofficial
 
         // 2**: things to do with the write loop
         /// <summary>
-        /// The socket-writerreached a natural EOF from the pipe
+        /// The socket-writer reached a natural EOF from the pipe
         /// </summary>
         WriteEndOfStream = 200,
         /// <summary>

--- a/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
+++ b/src/Pipelines.Sockets.Unofficial/SocketConnection.cs
@@ -79,7 +79,7 @@ namespace Pipelines.Sockets.Unofficial
         /// </summary>
         WriteSocketError = 205,
 
-        // 2**: things to do with the reader/writer themselves
+        // 3**: things to do with the reader/writer themselves
         /// <summary>
         /// The input's reader was completed
         /// </summary>


### PR DESCRIPTION
I found a small typo in PipeShutdownKind enum comment and found that SocketConnection used deprecated Thread.VolatileRead(int) method. Boy scout PR.